### PR TITLE
Hotfix for GCC 7.2

### DIFF
--- a/build.py
+++ b/build.py
@@ -105,16 +105,6 @@ class ConanDockerTools(object):
                                   "-s compiler.libcxx=libstdc++ --build" %
                                   (container_name, compiler_name, compiler_version), shell=True)
 
-            if compiler_name == "clang":
-                subprocess.check_call("docker exec %s conan install zlib/1.2.11@conan/stable "
-                                      "-s arch=x86_64 -s compiler=%s -s compiler.version=%s "
-                                      "-s compiler.libcxx=libstdc++ --build" %
-                                      (container_name, compiler_name, compiler_version), shell=True)
-                subprocess.check_call("docker exec %s conan install zlib/1.2.11@conan/stable "
-                                      "-s arch=x86 -s compiler=%s -s compiler.version=%s "
-                                      "-s compiler.libcxx=libstdc++ --build" %
-                                      (container_name, compiler_name, compiler_version), shell=True)
-
         finally:
             subprocess.call("docker stop %s" % container_name, shell=True)
             subprocess.call("docker rm %s" % container_name, shell=True)

--- a/build.py
+++ b/build.py
@@ -91,6 +91,20 @@ class ConanDockerTools(object):
                                   "-s compiler.libcxx=libstdc++ --build" %
                                   (container_name, compiler_name, compiler_version), shell=True)
 
+            subprocess.check_call("docker exec %s conan remote add conan-community "
+                                  "https://api.bintray.com/conan/conan-community/conan "
+                                  "--insert" %
+                                  container_name, shell=True)
+
+            subprocess.check_call("docker exec %s conan install gtest/1.8.0@conan/stable -s "
+                                  "arch=x86_64 -s compiler=%s -s compiler.version=%s "
+                                  "-s compiler.libcxx=libstdc++ --build" %
+                                  (container_name, compiler_name, compiler_version), shell=True)
+            subprocess.check_call("docker exec %s conan install gtest/1.8.0@conan/stable "
+                                  "-s arch=x86 -s compiler=%s -s compiler.version=%s "
+                                  "-s compiler.libcxx=libstdc++ --build" %
+                                  (container_name, compiler_name, compiler_version), shell=True)
+
             if compiler_name == "clang":
                 subprocess.check_call("docker exec %s conan install zlib/1.2.11@conan/stable "
                                       "-s arch=x86_64 -s compiler=%s -s compiler.version=%s "

--- a/conan_server/Dockerfile
+++ b/conan_server/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6-alpine3.6
 
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
 ENV CONAN_VERSION=0.27.0
 
 ADD https://github.com/conan-io/conan/archive/${CONAN_VERSION}.zip /

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -12,6 +12,7 @@ RUN dpkg --add-architecture i386 \
        git=1:2.14.* \
        vim=2:8.0.* \
        libc6-dev-i386=2.26-* \
+       linux-libc-dev:i386=4.13.* \
        g++-7-multilib=7.2.* \
        libgmp-dev=2:6.1.* \
        libmpfr-dev=3.1.* \
@@ -23,6 +24,8 @@ RUN dpkg --add-architecture i386 \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.9.0-Linux-x86_64.tar.gz \

--- a/testimage/Dockerfile
+++ b/testimage/Dockerfile
@@ -1,5 +1,5 @@
 FROM lasote/conangcc63
 
-MAINTAINER Luis Martinez de Bartolome
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 RUN sudo pip uninstall -y conan


### PR DESCRIPTION
Hi!

* After to install g++-7.2 the system doesn't solve c++ and g++ default names, so I used *update-alternatives* for that. 
* Also, when we need to build a C++ package for x86, the header *asm/error.h* is not found. I added *linux-libc-dev:i386* to solve that
* To make sure for next changes, I added a c++ package build (GTest). Unfortunately, conan-center doesn't provide any C++ package, only header only or Poco, but Poco is huge for a simple test. So, I added conan-community. 

Regards