### PR TITLE
Hotfix Clang 5.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -74,8 +74,11 @@ class ConanDockerTools(object):
         """
         logging.info("Testing Docker by service %s." % service)
         try:
-            subprocess.check_call("docker exec %s sudo install -U conan" % service, shell=True)
-            subprocess.check_call("docker exec %s sudo install -U conan_package_tools" % service, shell=True)
+            image = "%s/%s:%s" % (self.variables.docker_username, service, self.variables.docker_build_tag)
+            subprocess.check_call("docker run -t -d --name %s %s" % (service, image), shell=True)
+
+            subprocess.check_call("docker exec %s sudo pip install -U conan" % service, shell=True)
+            subprocess.check_call("docker exec %s sudo pip install -U conan_package_tools" % service, shell=True)
             subprocess.check_call("docker exec %s conan user" % service, shell=True)
 
             subprocess.check_call("docker exec %s conan install zlib/1.2.11@conan/stable -s "

--- a/build.py
+++ b/build.py
@@ -74,39 +74,37 @@ class ConanDockerTools(object):
         """
         logging.info("Testing Docker by service %s." % service)
         try:
-            subprocess.check_call("docker-compose up -d %s" % service,
-                                  shell=True)
-            subprocess.check_call("docker-compose exec %s sudo pip install -U conan_package_tools" %
-                                  service, shell=True)
-            subprocess.check_call("docker-compose exec %s sudo pip install -U conan" % service,
-                                  shell=True)
-            subprocess.check_call("docker-compose exec %s conan user" % service, shell=True)
+            subprocess.check_call("docker exec %s sudo install -U conan" % service, shell=True)
+            subprocess.check_call("docker exec %s sudo install -U conan_package_tools" % service, shell=True)
+            subprocess.check_call("docker exec %s conan user" % service, shell=True)
 
-            subprocess.check_call("docker-compose exec %s conan install zlib/1.2.11@conan/stable -s "
+            subprocess.check_call("docker exec %s conan install zlib/1.2.11@conan/stable -s "
                                   "arch=x86_64 -s compiler=%s -s compiler.version=%s "
                                   "-s compiler.libcxx=libstdc++ --build" %
                                   (service, compiler_name, compiler_version), shell=True)
-            subprocess.check_call("docker-compose exec %s conan install zlib/1.2.11@conan/stable "
+
+            subprocess.check_call("docker exec %s conan install zlib/1.2.11@conan/stable "
                                   "-s arch=x86 -s compiler=%s -s compiler.version=%s "
                                   "-s compiler.libcxx=libstdc++ --build" %
                                   (service, compiler_name, compiler_version), shell=True)
 
-            subprocess.check_call("docker-compose exec %s conan remote add conan-community "
+            subprocess.check_call("docker exec %s conan remote add conan-community "
                                   "https://api.bintray.com/conan/conan-community/conan "
                                   "--insert" %
                                   service, shell=True)
 
-            subprocess.check_call("docker-compose exec %s conan install gtest/1.8.0@conan/stable -s "
+            subprocess.check_call("docker exec %s conan install gtest/1.8.0@conan/stable -s "
                                   "arch=x86_64 -s compiler=%s -s compiler.version=%s "
                                   "-s compiler.libcxx=libstdc++ --build" %
                                   (service, compiler_name, compiler_version), shell=True)
-            subprocess.check_call("docker-compose exec %s conan install gtest/1.8.0@conan/stable "
+            subprocess.check_call("docker exec %s conan install gtest/1.8.0@conan/stable "
                                   "-s arch=x86 -s compiler=%s -s compiler.version=%s "
                                   "-s compiler.libcxx=libstdc++ --build" %
                                   (service, compiler_name, compiler_version), shell=True)
 
         finally:
-            subprocess.call("docker-compose down", shell=True)
+            subprocess.call("docker stop %s" % service, shell=True)
+            subprocess.call("docker rm %s" % service, shell=True)
 
     def deploy(self, service):
         """Upload Docker image to dockerhub

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -2,6 +2,12 @@ FROM ubuntu:artful
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
+ENV LLVM_VERSION=5.0 \
+    CC=clang \
+    CXX=clang++ \
+    CMAKE_C_COMPILER=clang \
+    CMAKE_CXX_COMPILER=clang++
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
@@ -21,7 +27,7 @@ RUN dpkg --add-architecture i386 \
        nasm=2.13.01-2 \
        dh-autoreconf=14 \
        libffi-dev=3.2.1-6 \
-       libssl1.0.0=1.0.2g-1ubuntu13 \
+       libssl-dev=1.0.2g-1ubuntu13.2 \
        ninja-build=1.7.2-3 \
        libc++-dev=3.9.1-3 \
        libc++-dev:i386=3.9.1-3 \
@@ -31,6 +37,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-5.0 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-5.0 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-5.0 100 \
+    && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.9.0-Linux-x86_64.tar.gz \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,13 @@ services:
         image: "${DOCKER_USERNAME}/conanclang40:${DOCKER_BUILD_TAG}"
         container_name: conanclang40
         tty: true
+    conanclang50:
+        build:
+            context: clang_5.0
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/conanclang50:${DOCKER_BUILD_TAG}"
+        container_name: conanclang50
+        tty: true
     conan_server:
         build:
             context: conan_server

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -1,25 +1,29 @@
-FROM ubuntu:vivid
+FROM ubuntu:xenial
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       python-dev=2.7.* \
-       sudo=1.8.* \
-       build-essential=11.* \
-       wget=1.16.* \
-       git=1:2.1.* \
-       vim=2:7.4.* \
-       libc6-dev-i386=2.21-* \
-       g++-multilib=4:4.9.* \
-       nasm=2.11.* \
-       dh-autoreconf=10 \
-       valgrind=1:3.10.* \
-       ninja-build=1.3.* \
-       libffi-dev=3.2.* \
-       libssl-dev=1.0.* \
+       python-dev=2.7.11-1 \
+       sudo=1.8.16-0ubuntu1 \
+       g++-4.9=4.9.3-13ubuntu2 \
+       g++-4.9-multilib=4.9.3-13ubuntu2 \
+       libc6-dev-i386=2.23-0ubuntu9 \
+       wget=1.17.1-1ubuntu1 \
+       git=1:2.7.4-0ubuntu1 \
+       vim=2:7.4.1689-3ubuntu1.2 \
+       nasm=2.11.08-1 \
+       dh-autoreconf=11 \
+       valgrind=1:3.11.0-1ubuntu4 \
+       ninja-build=1.5.1-0.1ubuntu1 \
+       libffi-dev=3.2.1-4 \
+       libssl-dev=1.0.2g-1ubuntu4.9 \
     && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
     && wget -q --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.9.0-Linux-x86_64.tar.gz \
     && cp -fR cmake-3.9.0-Linux-x86_64/* /usr \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -9,6 +9,7 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.16-0ubuntu1 \
        g++-4.9=4.9.3-13ubuntu2 \
        g++-4.9-multilib=4.9.3-13ubuntu2 \
+       gcc-multilib=4:5.3.1-1ubuntu1 \
        libc6-dev-i386=2.23-0ubuntu9 \
        wget=1.17.1-1ubuntu1 \
        git=1:2.7.4-0ubuntu1 \


### PR DESCRIPTION
Hi!

This PR brings some important fixes and improvements.

* As discussed at #27, I moved from vivid to xenial
* Docker compose has some problem to execute under Travis environment, so I reverted to use docker exec when necessary
* Improved Clang image test to build both zlib and GTest using libstdc++ and libc++
* Fixed Clang 5.0, see: https://github.com/conan-io/conan-package-tools/issues/124
* After to add libc++ test, clang-5.0 failed to build using arch=x86. There is a known bug, as workaround I made a symbolic link to locale.h -- I found this solution at Ubuntu forum.

Regards!

Closes #27 