### PR TITLE
Fix Clang images (#32)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - GCC_VERSIONS="5.2"
     - GCC_VERSIONS="5.3"
     - GCC_VERSIONS="5.4"
-    - GCC_VERSIONS="6.2"
     - GCC_VERSIONS="6.3"
     - GCC_VERSIONS="6.4"
     - GCC_VERSIONS="7.2"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The images are uploaded to Dockerhub:
 | [lasote/conangcc54: gcc 5.4](https://hub.docker.com/r/lasote/conangcc54/)   |  Supported |
 | [lasote/conangcc62: gcc 6.2](https://hub.docker.com/r/lasote/conangcc62/)   |  DEPRECATED, only frozen binary image support, No Dockerfile |
 | [lasote/conangcc63: gcc 6.3](https://hub.docker.com/r/lasote/conangcc63/)   |  Supported |
+| [lasote/conangcc64: gcc 6.4](https://hub.docker.com/r/lasote/conangcc64/)   |  Supported |
 | [lasote/conangcc71: gcc 7.1](https://hub.docker.com/r/lasote/conangcc71/)   |  DEPRECATED, only frozen binary image support, No Dockerfile |
 | [lasote/conangcc72: gcc 7.2](https://hub.docker.com/r/lasote/conangcc72/)   |  Supported |
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,19 @@ The images are uploaded to Dockerhub:
 | [lasote/conangcc52: gcc 5.2](https://hub.docker.com/r/lasote/conangcc52/)   |  Supported |
 | [lasote/conangcc53: gcc 5.3](https://hub.docker.com/r/lasote/conangcc53/)   |  Supported |
 | [lasote/conangcc54: gcc 5.4](https://hub.docker.com/r/lasote/conangcc54/)   |  Supported |
-| [lasote/conangcc62: gcc 6.2](https://hub.docker.com/r/lasote/conangcc62/)   |  Supported |
+| [lasote/conangcc62: gcc 6.2](https://hub.docker.com/r/lasote/conangcc62/)   |  DEPRECATED, only frozen binary image support, No Dockerfile |
 | [lasote/conangcc63: gcc 6.3](https://hub.docker.com/r/lasote/conangcc63/)   |  Supported |
 | [lasote/conangcc71: gcc 7.1](https://hub.docker.com/r/lasote/conangcc71/)   |  DEPRECATED, only frozen binary image support, No Dockerfile |
 | [lasote/conangcc72: gcc 7.2](https://hub.docker.com/r/lasote/conangcc72/)   |  Supported |
+
+GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are generic images by major version. If you are interested to understand the motivation, read this [issue](https://github.com/conan-io/conan/issues/1214).
+
+| Version                                                                     |  Status, Life cycle  |
+|-----------------------------------------------------------------------------|------------|
+| [lasote/conangcc5: gcc 5](https://hub.docker.com/r/lasote/conangcc5/)   |  Supported |
+| [lasote/conangcc6: gcc 6](https://hub.docker.com/r/lasote/conangcc6/)   |  Supported |
+| [lasote/conangcc7: gcc 7](https://hub.docker.com/r/lasote/conangcc7/)   |  Supported |
+
 
 #### Clang
 
@@ -28,7 +37,7 @@ The images are uploaded to Dockerhub:
 | - [lasote/conanclang38: clang 3.8](https://hub.docker.com/r/lasote/conanclang38/)   |  Supported |
 | - [lasote/conanclang39: clang 3.9](https://hub.docker.com/r/lasote/conanclang39/)   |  Supported |
 | - [lasote/conanclang40: clang 4.0](https://hub.docker.com/r/lasote/conanclang40/)   |  Supported |
-| - [lasote/conanclang40: clang 5.0](https://hub.docker.com/r/lasote/conanclang50/)   |  Supported |
+| - [lasote/conanclang50: clang 5.0](https://hub.docker.com/r/lasote/conanclang50/)   |  Supported |
 
 
 Use the images to test your c++ project in travis-ci

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -8,6 +8,8 @@ ENV LLVM_VERSION=3.8 \
     CMAKE_C_COMPILER=clang \
     CMAKE_CXX_COMPILER=clang++
 
+COPY sources.list /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/clang_3.8/sources.list
+++ b/clang_3.8/sources.list
@@ -1,0 +1,4 @@
+deb http://old-releases.ubuntu.com/ubuntu/ zesty main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-security main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-backports main restricted universe multiverse

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -8,6 +8,8 @@ ENV LLVM_VERSION=3.9 \
     CMAKE_C_COMPILER=clang \
     CMAKE_CXX_COMPILER=clang++
 
+COPY sources.list /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/clang_3.9/sources.list
+++ b/clang_3.9/sources.list
@@ -1,0 +1,4 @@
+deb http://old-releases.ubuntu.com/ubuntu/ zesty main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-security main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-backports main restricted universe multiverse

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -8,6 +8,8 @@ ENV LLVM_VERSION=4.0 \
     CMAKE_C_COMPILER=clang \
     CMAKE_CXX_COMPILER=clang++
 
+COPY sources.list /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/clang_4.0/sources.list
+++ b/clang_4.0/sources.list
@@ -1,0 +1,4 @@
+deb http://old-releases.ubuntu.com/ubuntu/ zesty main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-security main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-backports main restricted universe multiverse

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -20,7 +20,7 @@ RUN dpkg --add-architecture i386 \
        clang-5.0=1:5.0-3 \
        make=4.1-9.1 \
        valgrind=1:3.13.0-1ubuntu2 \
-       libc6-dev-i386=2.26-0ubuntu2 \
+       libc6-dev-i386=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \
        libmpc-dev=1.0.3-2 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,13 @@ services:
         image: "${DOCKER_USERNAME}/conangcc63:${DOCKER_BUILD_TAG}"
         container_name: conangcc63
         tty: true
+    conangcc64:
+        build:
+            context: gcc_6.4
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/conangcc64:${DOCKER_BUILD_TAG}"
+        container_name: conangcc64
+        tty: true
     conangcc7:
         build:
             context: gcc_7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,13 +56,6 @@ services:
         image: "${DOCKER_USERNAME}/conangcc6:${DOCKER_BUILD_TAG}"
         container_name: conangcc6
         tty: true
-    conangcc62:
-        build:
-            context: gcc_6.2
-            dockerfile: Dockerfile
-        image: "${DOCKER_USERNAME}/conangcc62:${DOCKER_BUILD_TAG}"
-        container_name: conangcc62
-        tty: true
     conangcc63:
         build:
             context: gcc_6.3

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -10,7 +10,7 @@ RUN dpkg --add-architecture i386 \
        g++-4.9=4.9.3-13ubuntu2 \
        g++-4.9-multilib=4.9.3-13ubuntu2 \
        gcc-multilib=4:5.3.1-1ubuntu1 \
-       libc6-dev-i386=2.23-0ubuntu9 \
+       libc6-dev-i386=2.23-0ubuntu10 \
        wget=1.17.1-1ubuntu1 \
        git=1:2.7.4-0ubuntu1 \
        vim=2:7.4.1689-3ubuntu1.2 \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:yakkety
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
+COPY sources.list /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/gcc_6.2/sources.list
+++ b/gcc_6.2/sources.list
@@ -1,0 +1,4 @@
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-security main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-backports main restricted universe multiverse

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:zesty
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
+COPY sources.list /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/gcc_6.3/sources.list
+++ b/gcc_6.3/sources.list
@@ -1,0 +1,4 @@
+deb http://old-releases.ubuntu.com/ubuntu/ zesty main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-security main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ zesty-backports main restricted universe multiverse


### PR DESCRIPTION
Hi!

I updated all clang images to use Ubuntu 17.10 (artful) as base to fix Zesty EOL. Also, artful will end in the middle of this year.

I tried to use Bionic, but there is an error when it try to install lib32stdc++6. Bionic is under development, so I want to update all images in April.

Also, I just removed all package versions because we need to fix clang and put Bincrafters back on the rails. But I promise that I will restore package versions during #31 

Regards!