### PR TITLE
- create /usr/include/xlocale.h

### DIFF
--- a/gcc_6-i386/Dockerfile
+++ b/gcc_6-i386/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-6 100 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.10/cmake-3.10.1.tar.gz \
     && tar -xzf cmake-3.10.1.tar.gz \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -29,6 +29,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-6 100 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.10.1-Linux-x86_64.tar.gz \

--- a/gcc_7-i386/Dockerfile
+++ b/gcc_7-i386/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-7 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.10/cmake-3.10.1.tar.gz \
     && tar -xzf cmake-3.10.1.tar.gz \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -27,6 +27,7 @@ RUN dpkg --add-architecture i386 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.10.1-Linux-x86_64.tar.gz \


### PR DESCRIPTION
lasote/conangcc6 and lasote/conangcc7 images has no /usr/include/xlocale.h (same for i386 images)

as result cpprestsdk fails to build:
https://travis-ci.org/bincrafters/conan-cpprestsdk/jobs/342936065

```
sse4@sse4-VirtualBox:~/conan$ docker run --rm -it lasote/conangcc5
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

conan@9ac51cae25b0:~$ file /usr/include/xlocale.h
/usr/include/xlocale.h: ASCII text
```

```
sse4@sse4-VirtualBox:~/conan$ docker run --rm -it lasote/conangcc6
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

conan@f3f704782a3a:~$ file /usr/include/xlocale.h
/usr/include/xlocale.h: cannot open `/usr/include/xlocale.h' (No such file or directory)
```

```
sse4@sse4-VirtualBox:~/conan$ docker run --rm -it lasote/conangcc7
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

conan@09af30571e2e:~$ file /usr/include/xlocale.h
/usr/include/xlocale.h: cannot open `/usr/include/xlocale.h' (No such file or directory)
```

see also https://bugs.launchpad.net/ubuntu/+source/libc++/+bug/1725858

/cc @memsharded @lasote 