### PR TITLE
#47 include subversion in images

### DIFF
--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -40,6 +40,7 @@ RUN dpkg --add-architecture i386 \
        libc++abi-dev=3.9.* \
        libc++abi-dev:i386=3.9.* \
        pkg-config=0.29.1-0ubuntu1 \
+       subversion=1.9.5-1ubuntu1.1 \
        ca-certificates \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get -qq update \
        libc++-dev=3.9.1-3 \
        libc++abi-dev=3.9.1-3 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -38,6 +38,7 @@ RUN dpkg --add-architecture i386 \
        libc++abi-dev=3.9.1-3 \
        libc++abi-dev:i386=3.9.1-3 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get -qq update \
        libc++-dev=3.9.1-3 \
        libc++abi-dev=3.9.1-3 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -38,6 +38,7 @@ RUN dpkg --add-architecture i386 \
        libc++abi-dev=3.9.1-3 \
        libc++abi-dev:i386=3.9.1-3 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get -qq update \
        libc++-dev=3.9.1-3 \
        libc++abi-dev=3.9.1-3 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-5.0 100 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -34,6 +34,7 @@ RUN dpkg --add-architecture i386 \
        libc++abi-dev=3.9.1-3 \
        libc++abi-dev:i386=3.9.1-3 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-5.0 100 \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get -qq update \
        libc++-dev=6.0-2 \
        libc++abi-dev=6.0-2 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-4ubuntu1 \
        ca-certificates=20180409 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -34,6 +34,7 @@ RUN dpkg --add-architecture i386 \
        libc++abi-dev=6.0-2 \
        libc++abi-dev:i386=6.0-2 \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-4ubuntu1 \
        ca-certificates=20180409 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100 \

--- a/conan_server/Dockerfile
+++ b/conan_server/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-alpine3.6
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CONAN_VERSION=1.2
+ENV CONAN_VERSION=1.6.0
 
 ADD https://github.com/conan-io/conan/archive/${CONAN_VERSION}.zip /
 

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -qq update \
        libffi-dev=3.0.* \
        libssl-dev=1.0.* \
        pkg-config=0.26-1ubuntu1 \
+       subversion=1.6.17dfsg-3ubuntu3.5 \
        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -20,6 +20,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.1* \
        libssl-dev=1.0.* \
        pkg-config=0.26-1ubuntu4 \
+       subversion=1.8.8-1ubuntu3.3 \
        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -26,6 +26,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.2 \
        libssl-dev=1.* \
        pkg-config=0.26-1ubuntu4 \
+       subversion=1.8.8-1ubuntu3.3 \
        ca-certificates=20170717~14.04.1 \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100 \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -25,6 +25,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.2 \
        libssl-dev=1.* \
        pkg-config=0.26-1ubuntu4 \
+       subversion=1.8.8-1ubuntu3.3 \
        ca-certificates=20170717~14.04.1 \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100 \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -qq update \
        ninja-build=1.5.1-0.1ubuntu1  \
        libffi-dev=3.2.1-4 \
        libssl-dev=1.0.2* \
+       subversion=1.9.3-2ubuntu1.1 \
        pkg-config=0.29.1-0ubuntu1 \
        ca-certificates=20170717~16.04.1 \
        && rm -rf /var/lib/apt/lists/* \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -21,6 +21,7 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     libffi-dev=3.2.* \
     libssl-dev=1.0.2* \
     pkg-config=0.28-1ubuntu1 \
+    subversion=1.8.13-1ubuntu3 \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -69,6 +69,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu1 \
+       subversion=1.9.3-2ubuntu1.1 \
        ca-certificates \
     && ln -s /usr/bin/g++-5 /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -24,6 +24,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu1 \
+       subversion=1.9.3-2ubuntu1.1 \
        ca-certificates \
        && rm -rf /var/lib/apt/lists/* \
        && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -24,6 +24,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu1 \
+       subversion=1.9.3-2ubuntu1.1 \
        ca-certificates \
        && rm -rf /var/lib/apt/lists/* \
        && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq update \
        libffi-dev=3.2.1-6 \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-6 100 \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -26,6 +26,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu1 \
+       subversion=1.9.4-1ubuntu1 \
        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -26,6 +26,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.* \
        pkg-config=0.29.1-0ubuntu1 \
+       subversion=1.9.5-1ubuntu1.1 \
        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -25,6 +25,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-6 100 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -25,6 +25,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-6 100 \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq update \
        libffi-dev=3.2.1-6 \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -25,6 +25,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -25,6 +25,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-2ubuntu1 \
        ca-certificates=20170717 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq update \
        libffi-dev=3.2.1-8 \
        libssl-dev=1.* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-4ubuntu1 \
        ca-certificates=20180409 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100 \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -25,6 +25,7 @@ RUN dpkg --add-architecture i386 \
        libffi-dev=3.2.1-8 \
        libssl-dev=1.* \
        pkg-config=0.29.1-0ubuntu2 \
+       subversion=1.9.7-4ubuntu1 \
        ca-certificates=20180409 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100 \


### PR DESCRIPTION
This PR brings:

- Update ALL images with subversion package (SVN)
- Update Conan docker image to version 1.6.0

closes #47 