### PR TITLE
Add foreign architectures for package manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ services:
   - docker
 
 env:
-  global:
-    - DOCKER_UPLOAD="TRUE"
-    - DOCKER_USERNAME="conanio"
-    - DOCKER_LOGIN_USERNAME="lasote"
-
   matrix:
     - GCC_VERSIONS="5" DOCKER_ARCHS="x86"
     - GCC_VERSIONS="5"

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -13,6 +13,8 @@ ENV CC=arm-linux-gnueabihf-gcc-4.9 \
     LD=arm-linux-gnueabihf-ld \
     FC=arm-linux-gnueabihf-gfortran-4.9
 
+RUN sudo dpkg --add-architecture armhf
+
 RUN sudo apt-get -qq update \
     && sudo apt-get -qq install -y --force-yes --no-install-recommends \
        ".*4\.9.*arm-linux-gnueabihf.*" \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -13,9 +13,8 @@ ENV CC=arm-linux-gnueabihf-gcc-4.9 \
     LD=arm-linux-gnueabihf-ld \
     FC=arm-linux-gnueabihf-gfortran-4.9
 
-RUN sudo dpkg --add-architecture armhf
-
-RUN sudo apt-get -qq update \
+RUN sudo dpkg --add-architecture armhf \
+    && sudo apt-get -qq update \
     && sudo apt-get -qq install -y --force-yes --no-install-recommends \
        ".*4\.9.*arm-linux-gnueabihf.*" \
     && sudo rm -rf /var/lib/apt/lists/* \

--- a/gcc_4.9-armv7hf/test.sh
+++ b/gcc_4.9-armv7hf/test.sh
@@ -4,5 +4,6 @@ sudo docker exec gcc49-armv7hf sudo pip install -U conan_package_tools && \
 sudo docker exec gcc49-armv7hf sudo pip install -U conan && \
 sudo docker exec gcc49-armv7hf conan user && \
 sudo docker exec gcc49-armv7hf conan install gtest/1.8.0@bincrafters/stable -s arch=armv7hf -s compiler=gcc -s compiler.version=4.9 -s compiler.libcxx=libstdc++ --build && \
+sudo docker exec gcc49-armv7hf sudo apt-get install libc6:armhf && \
 sudo docker stop gcc49-armv7hf && \
 sudo docker rm gcc49-armv7hf

--- a/gcc_5-armv7hf/Dockerfile
+++ b/gcc_5-armv7hf/Dockerfile
@@ -19,7 +19,7 @@ RUN sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list
 USER root
 RUN PREFIX="deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/" \
   && SUFFIX="main restricted universe multiverse" \
-  && DEST="/etc/apt/sources.list.d/armel.list" \
+  && DEST="/etc/apt/sources.list.d/armhf.list" \
   && echo "${PREFIX} xenial ${SUFFIX}" >> ${DEST} \
   && echo "${PREFIX} xenial-updates ${SUFFIX}" >> ${DEST} \
   && echo "${PREFIX} xenial-security ${SUFFIX}" >> ${DEST} \

--- a/gcc_5-armv7hf/Dockerfile
+++ b/gcc_5-armv7hf/Dockerfile
@@ -13,8 +13,21 @@ ENV CC=arm-linux-gnueabihf-gcc-5 \
     LD=arm-linux-gnueabihf-ld \
     FC=arm-linux-gnueabihf-gfortran-5
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get -qq install -y --force-yes --no-install-recommends \
+RUN sudo dpkg --add-architecture armhf
+RUN sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list
+
+USER root
+RUN PREFIX="deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/" \
+  && SUFFIX="main restricted universe multiverse" \
+  && DEST="/etc/apt/sources.list.d/armel.list" \
+  && echo "${PREFIX} xenial ${SUFFIX}" >> ${DEST} \
+  && echo "${PREFIX} xenial-updates ${SUFFIX}" >> ${DEST} \
+  && echo "${PREFIX} xenial-security ${SUFFIX}" >> ${DEST} \
+  && echo "${PREFIX} xenial-backports ${SUFFIX}" >> ${DEST}
+USER conan
+
+RUN sudo apt-get -q update \
+    && sudo apt-get -q install -y --no-install-recommends \
        ".*5.*arm-linux-gnueabihf.*" \
        binutils-arm-linux-gnueabi \
     && sudo rm -rf /var/lib/apt/lists/* \

--- a/gcc_6-armv7hf/Dockerfile
+++ b/gcc_6-armv7hf/Dockerfile
@@ -13,14 +13,27 @@ ENV CC=arm-linux-gnueabihf-gcc \
     LD=arm-linux-gnueabihf-ld \
     FC=arm-linux-gnueabihf-gfortran-6
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get -qq install -y --force-yes --no-install-recommends \
+RUN sudo dpkg --add-architecture armhf
+RUN sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list
+
+USER root
+RUN PREFIX="deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/" \
+  && SUFFIX="main restricted universe multiverse" \
+  && DEST="/etc/apt/sources.list.d/armhf.list" \
+  && echo "${PREFIX} artful ${SUFFIX}" >> ${DEST} \
+  && echo "${PREFIX} artful-updates ${SUFFIX}" >> ${DEST} \
+  && echo "${PREFIX} artful-security ${SUFFIX}" >> ${DEST} \
+  && echo "${PREFIX} artful-backports ${SUFFIX}" >> ${DEST}
+USER conan
+
+RUN sudo apt-get -q update \
+    && sudo apt-get -q install -y --no-install-recommends \
        ".*6.*arm-linux-gnueabihf.*" \
     && sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-6 100 \
     && sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-c++ arm-linux-gnueabihf-c++ /usr/bin/arm-linux-gnueabihf-g++-6 100 \
     && sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-6 100 \
     && sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-cc arm-linux-gnueabihf-cc /usr/bin/arm-linux-gnueabihf-gcc-6 100 \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo pip install -q --no-cache-dir conan --upgrade \
+    && pip install -q --no-cache-dir conan --upgrade \
     && conan profile new default --detect \
     && conan profile update settings.arch=armv7hf default


### PR DESCRIPTION
This is my first PR ever, so forgive me if I screw it up 😬. I added the foreign architecture just for the `gcc49-armv7hf` image for now so you could see what that would look like. I also added a statement to the `test.sh` script, but it looks like that doesn't get run for now anyway. The global variables in the `.travis.yaml` file were overriding the variables for the build plan in my Travis setup and causing the builds to fail. Consider removing them so others can fork and test in their own Travis builds. Anyway, let me know what you think and I could help do this for the other images.