### PR TITLE
Fix python 3 symlink on Clang 7 images

### DIFF
--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -41,6 +41,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \


### PR DESCRIPTION
On clang 7 images, `python` doesn't work. This PR add `python3` as default `python` symlink.