### PR TITLE
Fixing python path (#66)

### DIFF
--- a/build.py
+++ b/build.py
@@ -113,22 +113,22 @@ class ConanDockerTools(object):
                                     (service, sudo_command), shell=True)
                 subprocess.check_call("docker exec %s %s pip install --no-cache-dir -U conan" %
                                     (service, sudo_command), shell=True)
-                subprocess.check_call("docker exec %s %s conan user" % (service, sudo_command), shell=True)
+                subprocess.check_call("docker exec %s conan user" % service, shell=True)
 
-                if compiler_name == "clang" and compiler_version == "7":
-                        compiler_version = "7.0" # FIXME: Remove this when fixed in conan
+            if compiler_name == "clang" and compiler_version == "7":
+                    compiler_version = "7.0" # FIXME: Remove this when fixed in conan
 
-                subprocess.check_call("docker exec %s %s conan install lz4/1.8.3@bincrafters/stable -s "
-                                    "arch=%s -s compiler=%s -s compiler.version=%s --build" %
-                                    (service, sudo_command, arch, compiler_name,
-                                    compiler_version), shell=True)
+            subprocess.check_call("docker exec %s conan install lz4/1.8.3@bincrafters/stable -s "
+                                "arch=%s -s compiler=%s -s compiler.version=%s --build" %
+                                (service, arch, compiler_name,
+                                compiler_version), shell=True)
 
-                for libcxx in libcxx_list:
-                    subprocess.check_call("docker exec %s %s conan install gtest/1.8.1@bincrafters/stable -s "
-                                        "arch=%s -s compiler=%s -s compiler.version=%s "
-                                        "-s compiler.libcxx=%s --build" %
-                                        (service, sudo_command, arch, compiler_name,
-                                        compiler_version, libcxx), shell=True)
+            for libcxx in libcxx_list:
+                subprocess.check_call("docker exec %s conan install gtest/1.8.1@bincrafters/stable -s "
+                                    "arch=%s -s compiler=%s -s compiler.version=%s "
+                                    "-s compiler.libcxx=%s --build" %
+                                    (service, arch, compiler_name,
+                                    compiler_version, libcxx), shell=True)
         finally:
             subprocess.call("docker stop %s" % service, shell=True)
             subprocess.call("docker rm %s" % service, shell=True)

--- a/build.py
+++ b/build.py
@@ -37,7 +37,6 @@ class ConanDockerTools(object):
         docker_username = os.getenv("DOCKER_USERNAME", "conanio")
         docker_login_username = os.getenv("DOCKER_LOGIN_USERNAME", "lasote")
         docker_build_tag = os.getenv("DOCKER_BUILD_TAG", "latest")
-        sudo_command = self._get_boolean_var("DOCKER_SUDO")
         docker_archs = os.getenv("DOCKER_ARCHS").split(",") if os.getenv("DOCKER_ARCHS") else ["x86_64"]
         os.environ["DOCKER_USERNAME"] = docker_username
         os.environ["DOCKER_BUILD_TAG"] = docker_build_tag
@@ -49,15 +48,9 @@ class ConanDockerTools(object):
                                                         "docker_username, docker_login_username, "
                                                         "gcc_versions, "
                                                         "clang_versions, build_server, docker_build_tag, "
-                                                        "docker_archs, sudo_command")
+                                                        "docker_archs")
         return Variables(docker_upload, docker_password, docker_username, docker_login_username,
-                         gcc_versions, clang_versions, build_server, docker_build_tag, docker_archs
-                         , sudo_command)
-
-    def _get_sudo_command(self):
-        """ Return sudo command name when required
-        """
-        return "sudo" if self.variables.sudo_command else ""
+                         gcc_versions, clang_versions, build_server, docker_build_tag, docker_archs)
 
     def _get_boolean_var(self, var, default="false"):
         """ Parse environment variable as boolean type
@@ -81,13 +74,12 @@ class ConanDockerTools(object):
         subprocess.call('docker run --rm -i lukasmartinelli/hadolint < %s/Dockerfile' % build_dir,
                         shell=True)
 
-    def test(self, arch, compiler_name, compiler_version, service, sudo_command):
+    def test(self, arch, compiler_name, compiler_version, service):
         """Validate Docker image by Conan install
         :param arch: Name of he architecture
         :param compiler_name: Compiler to be specified as conan setting e.g. clang
         :param compiler_version: Compiler version to be specified as conan setting e.g. 3.8
         :param service: Docker compose service name
-        :param sudo_command: Linux sudo command
         """
         logging.info("Testing Docker by service %s." % service)
         try:
@@ -95,42 +87,48 @@ class ConanDockerTools(object):
             libcxx_list = ["libstdc++"] if compiler_name == "gcc" else ["libstdc++", "libc++"]
             subprocess.check_call("docker run -t -d --name %s %s" % (service, image), shell=True)
 
-            output = subprocess.check_output("docker exec %s python3 --version" % service, shell=True)
-            assert "Python 3" in output.decode()
-            logging.info("Found %s" % output.decode().rstrip())
+            for sudo_command in ["", "sudo", "sudo -E"]:
+                logging.info("Testing command prefix: '{}'".format(sudo_command))
+                output = subprocess.check_output("docker exec %s %s python3 --version" % (service, sudo_command), shell=True)
+                assert "Python 3" in output.decode()
+                logging.info("Found %s" % output.decode().rstrip())
 
-            output = subprocess.check_output("docker exec %s pip --version" % service, shell=True)
-            assert "python 3" in output.decode()
-            logging.info("Found pip (Python 3)")
+                output = subprocess.check_output("docker exec %s %s pip --version" % (service, sudo_command), shell=True)
+                assert "python 3" in output.decode()
+                logging.info("Found pip (Python 3)")
 
-            output = subprocess.check_output("docker exec %s pip show conan" % service, shell=True)
-            assert "python3" in output.decode()
-            logging.info("Found Conan (Python 3)")
+                output = subprocess.check_output("docker exec %s %s pip3 --version" % (service, sudo_command), shell=True)
+                assert "python 3" in output.decode()
+                logging.info("Found pip3 (Python 3)")
 
-            output = subprocess.check_output("docker exec %s python --version" % service, shell=True)
-            assert "Python 3" in output.decode()
-            logging.info("Default Python version: %s" % output.decode().rstrip())
+                output = subprocess.check_output("docker exec %s %s pip show conan" % (service, sudo_command), shell=True)
+                assert "python3" in output.decode()
+                logging.info("Found Conan (Python 3)")
 
-            subprocess.check_call("docker exec %s %s pip install --no-cache-dir -U conan_package_tools" %
-                                  (service, sudo_command), shell=True)
-            subprocess.check_call("docker exec %s %s pip install --no-cache-dir -U conan" %
-                                 (service, sudo_command), shell=True)
-            subprocess.check_call("docker exec %s conan user" % service, shell=True)
+                output = subprocess.check_output("docker exec %s %s python --version" % (service, sudo_command), shell=True)
+                assert "Python 3" in output.decode()
+                logging.info("Default Python version: %s" % output.decode().rstrip())
 
-            if compiler_name == "clang" and compiler_version == "7":
-                    compiler_version = "7.0" # FIXME: Remove this when fixed in conan
+                subprocess.check_call("docker exec %s %s pip install --no-cache-dir -U conan_package_tools" %
+                                    (service, sudo_command), shell=True)
+                subprocess.check_call("docker exec %s %s pip install --no-cache-dir -U conan" %
+                                    (service, sudo_command), shell=True)
+                subprocess.check_call("docker exec %s %s conan user" % (service, sudo_command), shell=True)
 
-            subprocess.check_call("docker exec %s conan install lz4/1.8.3@bincrafters/stable -s "
-                                  "arch=%s -s compiler=%s -s compiler.version=%s --build" %
-                                  (service, arch, compiler_name,
-                                   compiler_version), shell=True)
+                if compiler_name == "clang" and compiler_version == "7":
+                        compiler_version = "7.0" # FIXME: Remove this when fixed in conan
 
-            for libcxx in libcxx_list:
-                subprocess.check_call("docker exec %s conan install gtest/1.8.1@bincrafters/stable -s "
-                                      "arch=%s -s compiler=%s -s compiler.version=%s "
-                                      "-s compiler.libcxx=%s --build" %
-                                      (service, arch, compiler_name,
-                                       compiler_version, libcxx), shell=True)
+                subprocess.check_call("docker exec %s %s conan install lz4/1.8.3@bincrafters/stable -s "
+                                    "arch=%s -s compiler=%s -s compiler.version=%s --build" %
+                                    (service, sudo_command, arch, compiler_name,
+                                    compiler_version), shell=True)
+
+                for libcxx in libcxx_list:
+                    subprocess.check_call("docker exec %s %s conan install gtest/1.8.1@bincrafters/stable -s "
+                                        "arch=%s -s compiler=%s -s compiler.version=%s "
+                                        "-s compiler.libcxx=%s --build" %
+                                        (service, sudo_command, arch, compiler_name,
+                                        compiler_version, libcxx), shell=True)
         finally:
             subprocess.call("docker stop %s" % service, shell=True)
             subprocess.call("docker rm %s" % service, shell=True)
@@ -167,11 +165,10 @@ class ConanDockerTools(object):
                     tag_arch = "" if arch == "x86_64" else "-%s" % arch
                     service = "%s%s%s" % (compiler.name, version.replace(".", ""), tag_arch)
                     build_dir = "%s_%s%s" % (compiler.name, version, tag_arch)
-                    sudo_command =  self._get_sudo_command()
 
-                    self.linter(build_dir)
+                    #self.linter(build_dir)
                     self.build(service)
-                    self.test(arch, compiler.name, version, service, sudo_command)
+                    self.test(arch, compiler.name, version, service)
                     self.deploy(service)
 
         if self.variables.build_server:

--- a/build.py
+++ b/build.py
@@ -166,7 +166,7 @@ class ConanDockerTools(object):
                     service = "%s%s%s" % (compiler.name, version.replace(".", ""), tag_arch)
                     build_dir = "%s_%s%s" % (compiler.name, version, tag_arch)
 
-                    #self.linter(build_dir)
+                    self.linter(build_dir)
                     self.build(service)
                     self.test(arch, compiler.name, version, service)
                     self.deploy(service)

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -75,8 +75,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -74,7 +74,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -76,7 +76,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -77,8 +77,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -75,8 +75,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -74,7 +74,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -76,7 +76,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -77,8 +77,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -75,8 +75,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -74,7 +74,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -72,7 +72,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -73,8 +73,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -71,8 +71,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -70,7 +70,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -72,7 +72,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -73,8 +73,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -71,8 +71,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -70,7 +70,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -72,7 +72,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -73,8 +73,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -71,8 +71,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -70,7 +70,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -51,8 +51,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -50,7 +50,9 @@ RUN apt-get -qq update \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -53,8 +53,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -52,7 +52,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -43,6 +43,7 @@ RUN dpkg --add-architecture i386 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+    && sed -i '0,/python3/s//python2.7/' /usr/bin/lsb_release \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -51,7 +51,9 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 ENV CC=arm-linux-gnueabi-gcc-4.9 \
     CXX=arm-linux-gnueabi-g++-4.9 \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -52,8 +52,10 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 ENV CC=arm-linux-gnueabi-gcc-4.9 \
     CXX=arm-linux-gnueabi-g++-4.9 \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -54,8 +54,10 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 ENV CC=arm-linux-gnueabihf-gcc-4.9 \
     CXX=arm-linux-gnueabihf-g++-4.9 \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -53,7 +53,9 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 ENV CC=arm-linux-gnueabihf-gcc-4.9 \
     CXX=arm-linux-gnueabihf-g++-4.9 \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -62,7 +62,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -63,8 +63,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -53,6 +53,7 @@ RUN dpkg --add-architecture i386 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+    && sed -i '0,/python3/s//python2.7/' /usr/bin/lsb_release \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -59,7 +59,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -60,8 +60,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -50,6 +50,7 @@ RUN dpkg --add-architecture i386 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+    && sed -i '0,/python3/s//python2.7/' /usr/bin/lsb_release \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -58,7 +58,9 @@ RUN apt-get -qq update \
        && pyenv global 3.7.1 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan \
-       && chown -R conan:1001 /opt/pyenv
+       && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -59,8 +59,10 @@ RUN apt-get -qq update \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan \
        && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+       && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+       && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+       && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+       && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -52,7 +52,9 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -53,8 +53,10 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -101,7 +101,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -102,8 +102,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -56,8 +56,10 @@ RUN dpkg --add-architecture i386 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan \
        && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+       && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+       && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+       && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+       && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -55,7 +55,9 @@ RUN dpkg --add-architecture i386 \
        && pyenv global 3.7.1 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan \
-       && chown -R conan:1001 /opt/pyenv
+       && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -56,8 +56,10 @@ RUN dpkg --add-architecture i386 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan \
        && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+       && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+       && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+       && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+       && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -55,7 +55,9 @@ RUN dpkg --add-architecture i386 \
        && pyenv global 3.7.1 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan \
-       && chown -R conan:1001 /opt/pyenv
+       && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -65,7 +65,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -66,8 +66,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -57,7 +57,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -58,8 +58,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -57,7 +57,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -58,8 +58,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -60,7 +60,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -61,8 +61,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -61,7 +61,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -62,8 +62,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -65,7 +65,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -66,8 +66,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -58,7 +58,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -59,8 +59,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -59,7 +59,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -60,8 +60,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -65,7 +65,9 @@ RUN apt-get -qq update \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -66,8 +66,10 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -61,7 +61,9 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.1 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && ln -s /opt/pyenv/shims/python /usr/bin/python \
+    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -62,8 +62,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && ln -s /opt/pyenv/shims/python /usr/bin/python \
-    && ln -s /opt/pyenv/shims/pip /usr/bin/pip
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
 USER conan
 WORKDIR /home/conan


### PR DESCRIPTION
Hi!

I updated _python_ and _pip_ by **update-alternatives**:

```
update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 
&& update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims python3 100 \
&& update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
&& update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
```

Also, I added new tests to check `$ pip`, `$ sudo pip` and `$ sudo -E pip`. It's working.

update-alternatives could not be the best option, but as our image should run python3 by default I see no problem.

closes #66 