### PR TITLE
#73 Fix lsb_release for old distros

### DIFF
--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -48,7 +48,7 @@ RUN dpkg --add-architecture i386 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
-    && sed -i '0,/python3/s//python2.7/' /usr/bin/lsb_release \
+    && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
@@ -59,10 +59,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
-    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
+    && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -58,7 +58,7 @@ RUN dpkg --add-architecture i386 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
-    && sed -i '0,/python3/s//python2.7/' /usr/bin/lsb_release \
+    && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
@@ -69,10 +69,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
-    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
+    && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -55,7 +55,7 @@ RUN dpkg --add-architecture i386 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
-    && sed -i '0,/python3/s//python2.7/' /usr/bin/lsb_release \
+    && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
@@ -66,10 +66,10 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan \
     && chown -R conan:1001 /opt/pyenv \
-    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
-    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
+    && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100
 
 USER conan
 WORKDIR /home/conan


### PR DESCRIPTION
- Run lsb_release beased on generic python version
- Allow Python2 be installed by system and dont break things

Related issue: #73 