### PR TITLE
Allow centos image install pip packages without sudo

### DIFF
--- a/build.py
+++ b/build.py
@@ -126,7 +126,7 @@ class ConanDockerTools(object):
             image = "%s/%s:%s" % (self.variables.docker_username, service,
                                   self.variables.docker_build_tag)
             libcxx_list = ["libstdc++"] if compiler_name == "gcc" else ["libstdc++", "libc++"]
-            sudo_commands = ["sudo"] if distro else ["", "sudo", "sudo -E"]
+            sudo_commands = ["", "sudo"] if distro else ["", "sudo", "sudo -E"]
             subprocess.check_call("docker run -t -d --name %s %s" % (service, image), shell=True)
 
             for sudo_command in sudo_commands:

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -47,7 +47,9 @@ RUN yum update -y \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \
-    && printf "conan:conan" | chpasswd
+    && printf "conan:conan" | chpasswd \
+    && chgrp -R wheel /opt/rh/rh-python36/root \
+    && chmod -R g+w -R /opt/rh/rh-python36/root
 
 USER conan
 WORKDIR /home/conan


### PR DESCRIPTION
#### Description

To keep the same behavior between Ubuntu images and CentOS.

The user **conan** was added to **wheel** group and now all python base path owned by **wheel** group, which means both **root** and **conan** are able to install python packages.

#### Issues
- #83 