### PR TITLE
Docker image CentOS 6 x86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
   - docker
 env:
   matrix:
-    - GCC_VERSIONS="7" DOCKER_ARCHS="x86_64,x86" DOCKER_DISTRO="centos6"
+    - GCC_VERSIONS="7" DOCKER_ARCHS="x86_64" DOCKER_DISTRO="centos6"
+    - GCC_VERSIONS="7" DOCKER_ARCHS="x86" DOCKER_DISTRO="centos6"
 
     - GCC_VERSIONS="5" DOCKER_ARCHS="x86"
     - GCC_VERSIONS="5"

--- a/build.py
+++ b/build.py
@@ -102,8 +102,7 @@ class ConanDockerTools(object):
         :param service: service in compose e.g gcc54
         """
         logging.info("Starting build for service %s." % service)
-        # subprocess.check_call("docker-compose build --no-cache %s" % service, shell=True)
-        subprocess.check_call("docker-compose build %s" % service, shell=True)
+        subprocess.check_call("docker-compose build --no-cache %s" % service, shell=True)
 
     def linter(self, build_dir):
         """Execute hadolint to check possible prone errors
@@ -193,8 +192,9 @@ class ConanDockerTools(object):
             if "arm" in arch:
                 logging.warn("Skipping cmake_installer: cross-building results in Unverified HTTPS error")
             else:
+                subprocess.check_call("docker exec %s conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan" % service, shell=True)
                 subprocess.check_call(
-                    "docker exec %s conan install cmake_installer/3.13.0@conan/stable -s "
+                    "docker exec %s conan install ninja_installer/1.8.2@bincrafters/stable -s "
                     "arch_build=%s -s os_build=Linux --build" % (service, arch),
                     shell=True)
 

--- a/build.py
+++ b/build.py
@@ -102,7 +102,8 @@ class ConanDockerTools(object):
         :param service: service in compose e.g gcc54
         """
         logging.info("Starting build for service %s." % service)
-        subprocess.check_call("docker-compose build --no-cache %s" % service, shell=True)
+        # subprocess.check_call("docker-compose build --no-cache %s" % service, shell=True)
+        subprocess.check_call("docker-compose build %s" % service, shell=True)
 
     def linter(self, build_dir):
         """Execute hadolint to check possible prone errors
@@ -245,17 +246,13 @@ class ConanDockerTools(object):
     def run(self):
         """Execute all 3 stages for all versions in compilers list
         """
+        distro = "" if not self.variables.docker_distro else "-%s" % self.variables.docker_distro
         for arch in self.variables.docker_archs:
             for compiler in [self.gcc_compiler, self.clang_compiler]:
                 for version in compiler.versions:
-                    if self.variables.docker_distro:
-                        tag_arch = "-" + self.variables.docker_distro
-                    elif arch == "x86_64":
-                        tag_arch = ""
-                    else:
-                        tag_arch = "-%s" % arch
-                    service = "%s%s%s" % (compiler.name, version.replace(".", ""), tag_arch)
-                    build_dir = "%s_%s%s" % (compiler.name, version, tag_arch)
+                    tag_arch = "x86_64" if arch == "" else "-%s" % arch
+                    service = "%s%s%s%s" % (compiler.name, version.replace(".", ""), distro, tag_arch)
+                    build_dir = "%s_%s%s%s" % (compiler.name, version, distro, tag_arch)
 
                     self.login()
                     self.linter(build_dir)

--- a/build.py
+++ b/build.py
@@ -192,9 +192,8 @@ class ConanDockerTools(object):
             if "arm" in arch:
                 logging.warn("Skipping cmake_installer: cross-building results in Unverified HTTPS error")
             else:
-                subprocess.check_call("docker exec %s conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan" % service, shell=True)
                 subprocess.check_call(
-                    "docker exec %s conan install ninja_installer/1.8.2@bincrafters/stable -s "
+                    "docker exec %s conan install cmake_installer/3.13.0@conan/stable -s "
                     "arch_build=%s -s os_build=Linux --build" % (service, arch),
                     shell=True)
 

--- a/build.py
+++ b/build.py
@@ -250,7 +250,7 @@ class ConanDockerTools(object):
         for arch in self.variables.docker_archs:
             for compiler in [self.gcc_compiler, self.clang_compiler]:
                 for version in compiler.versions:
-                    tag_arch = "x86_64" if arch == "" else "-%s" % arch
+                    tag_arch = "" if arch == "x86_64" else "-%s" % arch
                     service = "%s%s%s%s" % (compiler.name, version.replace(".", ""), distro, tag_arch)
                     build_dir = "%s_%s%s%s" % (compiler.name, version, distro, tag_arch)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -295,3 +295,10 @@ services:
         image: "${DOCKER_USERNAME}/gcc7-centos6:${DOCKER_BUILD_TAG}"
         container_name: gcc7-centos6
         tty: true
+    gcc7-centos6-x86:
+        build:
+            context: gcc_7-centos6-x86
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/gcc7-centos6-x86:${DOCKER_BUILD_TAG}"
+        container_name: gcc7-centos6-x86
+        tty: true

--- a/gcc_7-centos6-x86/.dockerignore
+++ b/gcc_7-centos6-x86/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -1,0 +1,67 @@
+FROM i386/centos:6
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV PATH=/opt/rh/rh-python36/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:${PATH:+:${PATH}} \
+    MANPATH=/opt/rh/rh-python36/root/usr/share/man:/opt/rh/devtoolset-7/root/usr/share/man${MANPATH:+:${MANPATH}} \
+    INFOPATH=/opt/rh/devtoolset-7/root/usr/share/info${INFOPATH:+:${INFOPATH}} \
+    PCP_DIR=/opt/rh/devtoolset-7/root \
+    PERL5LIB=/opt/rh/devtoolset-7/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-7/root/usr/lib/perl5:/opt/rh/devtoolset-7/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}} \
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst:/opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    PKG_CONFIG_PATH=/opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS="/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+
+RUN printf "i686" >  /etc/yum/vars/arch \
+    && printf "i386" >  /etc/yum/vars/basearch \
+    && yum update -y \
+    && yum install -y centos-release-scl \
+    && yum install -y \
+       sudo \
+       wget \
+       git \
+       make \
+       valgrind \
+       glibc-devel \
+       gmp-devel \
+       mpfr-devel \
+       libmpc-devel \
+       nasm \
+       autoconf \
+       libffi-devel \
+       openssl-devel \
+       pkgconfig \
+       subversion \
+       zlib-devel \
+       xz \
+       curl \
+       xz-devel \
+       tar \
+       devtoolset-7-toolchain \
+       rh-python36 \
+    && yum clean all \
+    && wget --no-check-certificate --quiet -O /tmp/cmake-3.12.1.tar.gz https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz \
+    && tar -xzf /tmp/cmake-3.12.1.tar.gz -C /tmp \
+    && pushd /tmp/cmake-3.12.1 \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && popd \
+    && rm -rf /tmp/cmake- \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir conan \
+    && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
+    && groupadd 1001 -g 1001 \
+    && useradd -ms /bin/bash conan -g 1001 -G wheel \
+    && printf "conan:conan" | chpasswd \
+    && chgrp -R wheel /opt/rh/rh-python36/root \
+    && chmod -R g+w -R /opt/rh/rh-python36/root
+
+COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
+
+RUN yum update
+
+USER conan
+WORKDIR /home/conan
+
+
+

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -2,19 +2,18 @@ FROM i386/centos:6
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV PATH=/opt/rh/rh-python36/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:${PATH:+:${PATH}} \
-    MANPATH=/opt/rh/rh-python36/root/usr/share/man:/opt/rh/devtoolset-7/root/usr/share/man${MANPATH:+:${MANPATH}} \
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:${PATH:+:${PATH}} \
+    MANPATH=/opt/rh/devtoolset-7/root/usr/share/man${MANPATH:+:${MANPATH}} \
     INFOPATH=/opt/rh/devtoolset-7/root/usr/share/info${INFOPATH:+:${INFOPATH}} \
     PCP_DIR=/opt/rh/devtoolset-7/root \
     PERL5LIB=/opt/rh/devtoolset-7/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-7/root/usr/lib/perl5:/opt/rh/devtoolset-7/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}} \
-    LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst:/opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
-    PKG_CONFIG_PATH=/opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
-    XDG_DATA_DIRS="/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 
 RUN printf "i686" >  /etc/yum/vars/arch \
     && printf "i386" >  /etc/yum/vars/basearch \
     && yum update -y \
-    && yum install -y centos-release-scl \
     && yum install -y \
        sudo \
        wget \
@@ -37,7 +36,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
        xz-devel \
        tar \
        devtoolset-7-toolchain \
-       rh-python36 \
     && yum clean all \
     && wget --no-check-certificate --quiet -O /tmp/cmake-3.12.1.tar.gz https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz \
     && tar -xzf /tmp/cmake-3.12.1.tar.gz -C /tmp \
@@ -46,19 +44,15 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make -s -j`nproc` \
     && make -s install > /dev/null \
     && popd \
-    && rm -rf /tmp/cmake- \
-    && pip install --no-cache-dir --upgrade pip \
+    && rm -rf /tmp/cmake-
+
+RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
-    && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
-    && groupadd 1001 -g 1001 \
+    && sed -i 's/# %wheel/%wheel/g' /etc/sudoers
+
+RUN groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \
-    && printf "conan:conan" | chpasswd \
-    && chgrp -R wheel /opt/rh/rh-python36/root \
-    && chmod -R g+w -R /opt/rh/rh-python36/root
-
-COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
-
-RUN yum update
+    && printf "conan:conan" | chpasswd
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -1,13 +1,15 @@
 FROM i386/centos:6
+ENTRYPOINT ["linux32", "--"]
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:${PATH:+:${PATH}} \
+ENV PATH=/opt/pyenv/shims:/opt/rh/devtoolset-7/root/usr/bin:${PATH:+:${PATH}} \
     MANPATH=/opt/rh/devtoolset-7/root/usr/share/man${MANPATH:+:${MANPATH}} \
     INFOPATH=/opt/rh/devtoolset-7/root/usr/share/info${INFOPATH:+:${INFOPATH}} \
     PCP_DIR=/opt/rh/devtoolset-7/root \
     PERL5LIB=/opt/rh/devtoolset-7/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-7/root/usr/lib/perl5:/opt/rh/devtoolset-7/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}} \
-    LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    PYENV_ROOT=/opt/pyenv
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 
@@ -27,35 +29,64 @@ RUN printf "i686" >  /etc/yum/vars/arch \
        nasm \
        autoconf \
        libffi-devel \
-       openssl-devel \
        pkgconfig \
        subversion \
-       zlib-devel \
        xz \
        curl \
        xz-devel \
        tar \
        devtoolset-7-toolchain \
+       zlib-devel \
+       bzip2 \
+       bzip2-devel \
+       readline-devel \
+       sqlite \
+       sqlite-devel \
+       tk-devel \
+       libffi-devel \
+       libtool \
+       perl-core \
     && yum clean all \
     && wget --no-check-certificate --quiet -O /tmp/cmake-3.12.1.tar.gz https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz \
     && tar -xzf /tmp/cmake-3.12.1.tar.gz -C /tmp \
     && pushd /tmp/cmake-3.12.1 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
+    && ./bootstrap \
+    && make -s -j`nproc` > /dev/null \
     && make -s install > /dev/null \
     && popd \
-    && rm -rf /tmp/cmake-
-
-RUN pip install --no-cache-dir --upgrade pip \
+    && rm -rf /tmp/cmake-* \
+    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && chmod +x /tmp/pyenv-installer \
+    && /tmp/pyenv-installer \
+    && wget --quiet -O /tmp/OpenSSL_1_0_2q.tar.gz https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz \
+    && tar zxf /tmp/OpenSSL_1_0_2q.tar.gz -C /tmp \
+    && pushd /tmp/openssl-OpenSSL_1_0_2q \
+    && ./Configure --prefix=/usr shared zlib linux-generic32 \
+    && make -j`nproc` > /dev/null \
+    && make install > /dev/null \
+    && popd \
+    && rm -rf /tmp/openssl-* /tmp/OpenSSL* \
+    && rm /tmp/pyenv-installer \
+    && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
+    && pyenv install 3.6.7 \
+    && pyenv global 3.6.7 \
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
+    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan \
+    && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
-    && sed -i 's/# %wheel/%wheel/g' /etc/sudoers
-
-RUN groupadd 1001 -g 1001 \
+    && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
+    && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \
-    && printf "conan:conan" | chpasswd
+    && printf "conan:conan" | chpasswd \
+    && chown -R conan:1001 /opt/pyenv
 
 USER conan
 WORKDIR /home/conan
 
-
-
+RUN mkdir -p /home/conan/.conan \
+    && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \
+    && printf 'eval "$(pyenv virtualenv-init -)"\n' >> ~/.bashrc

--- a/gcc_7-centos6-x86/build.sh
+++ b/gcc_7-centos6-x86/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker build --no-cache  -t conanio/gcc7-centos6-x86 .

--- a/gcc_7-centos6-x86/cloudlinux.repo
+++ b/gcc_7-centos6-x86/cloudlinux.repo
@@ -1,0 +1,5 @@
+[cloudlinux]
+name=Cloud Linux
+baseurl=http://repo.cloudlinux.com/cloudlinux/6.10/sclo/devtoolset-7/i386/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Hi!

This new image is the support for CentOS 6 x86.

- Why did I replace cmake_installer by ninja_installer?

ninja_installer detected an error during centos cross-building (thanks to @SSE4). It could works better for regression tests.

- Why did I adde cloudlinux repo?

Unfortunately, Cent OS 6 doesn't not offer i386 package repo, thus devtoolset-7 is not available for download.

- Is it possible cross-build to x86 running centos6-x86_64

No. The package `devtoolset-7` is not available for i386. We could include cloudlinux repo and install, but this results in many conflicts for the amd64 version.

EDIT:

gcc4.6 is not able to build ninja installer, so I reverted to cmake_installer again.

Regards!