### PR TITLE
Reduce image size phase1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ env:
     - BUILD_CONAN_SERVER_IMAGE=1
 
 install:
-  - pip install conan
+  - pip install conan humanfriendly
 
 script:
   - python build.py

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -57,6 +57,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -24,7 +24,6 @@ RUN dpkg --add-architecture i386 \
        llvm-${LLVM_VERSION}-runtime=1:3.8.1-* \
        llvm=1:4.0-* \
        make=4.1-* \
-       valgrind=1:3.* \
        libc6-dev-i386=2.24-* \
        g++-multilib=4:6.3.* \
        libgmp-dev=2:6.1.* \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -18,7 +18,6 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.* \
        wget=1.18* \
        git=1:2.* \
-       vim=2:8.* \
        clang-${LLVM_VERSION}=1:3.8.1-* \
        llvm-${LLVM_VERSION}=1:3.8.1-* \
        llvm-${LLVM_VERSION}-dev=1:3.8.1-* \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -81,6 +81,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -qq update \
        sudo=1.8.20p2-1ubuntu1 \
        wget=1.19.1-3ubuntu1 \
        git=1:2.14.1-1ubuntu4 \
-       vim=2:8.0.0197-4ubuntu5 \
        g++=4:7.2.0-1ubuntu1 \
        clang-${LLVM_VERSION}=1:3.9.1-* \
        llvm-${LLVM_VERSION}=1:3.9.1-* \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get -qq update \
        llvm-${LLVM_VERSION}-runtime=1:3.9.1-* \
        llvm=1:4.0-* \
        make=4.1-9.1 \
-       valgrind=1:3.13.0-1ubuntu2 \
        libc6-dev=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.20p2-1ubuntu1 \
        wget=1.19.1-3ubuntu1 \
        git=1:2.14.1-1ubuntu4 \
-       vim=2:8.0.0197-4ubuntu5 \
        g++-multilib=4:7.2.0-1ubuntu1 \
        clang-${LLVM_VERSION}=1:3.9.1-* \
        llvm-${LLVM_VERSION}=1:3.9.1-* \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -57,6 +57,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -23,7 +23,6 @@ RUN dpkg --add-architecture i386 \
        llvm-${LLVM_VERSION}-runtime=1:3.9.1-* \
        llvm=1:4.0-* \
        make=4.1-9.1 \
-       valgrind=1:3.13.0-1ubuntu2 \
        libc6-dev-i386=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -81,6 +81,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get -qq update \
        llvm-${LLVM_VERSION}-runtime=1:4.0.1-6 \
        llvm=1:4.0-37~exp3ubuntu1 \
        make=4.1-9.1 \
-       valgrind=1:3.13.0-1ubuntu2 \
        libc6-dev=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -qq update \
        sudo=1.8.20p2-1ubuntu1 \
        wget=1.19.1-3ubuntu1 \
        git=1:2.14.1-1ubuntu4 \
-       vim=2:8.0.0197-4ubuntu5 \
        g++=4:7.2.0-1ubuntu1 \
        clang-${LLVM_VERSION}=1:4.0.1-6 \
        llvm-${LLVM_VERSION}=1:4.0.1-6 \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.20p2-1ubuntu1 \
        wget=1.19.1-3ubuntu1 \
        git=1:2.14.1-1ubuntu4 \
-       vim=2:8.0.0197-4ubuntu5 \
        g++-multilib=4:7.2.0-1ubuntu1 \
        clang-${LLVM_VERSION}=1:4.0.1-6 \
        llvm-${LLVM_VERSION}=1:4.0.1-6 \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -57,6 +57,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -23,7 +23,6 @@ RUN dpkg --add-architecture i386 \
        llvm-${LLVM_VERSION}-runtime=1:4.0.1-6 \
        llvm=1:4.0-37~exp3ubuntu1 \
        make=4.1-9.1 \
-       valgrind=1:3.13.0-1ubuntu2 \
        libc6-dev-i386=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -81,6 +81,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -76,6 +76,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get -qq update \
        g++=4:7.2.0-1ubuntu1 \
        clang-5.0=1:5.0-3 \
        make=4.1-9.1 \
-       valgrind=1:3.13.0-1ubuntu2 \
        libc6-dev=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -qq update \
        sudo=1.8.20p2-1ubuntu1 \
        wget=1.19.1-3ubuntu1 \
        git=1:2.14.1-1ubuntu4 \
-       vim=2:8.0.0197-4ubuntu5 \
        g++=4:7.2.0-1ubuntu1 \
        clang-5.0=1:5.0-3 \
        make=4.1-9.1 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.20p2-1ubuntu1 \
        wget=1.19.1-3ubuntu1 \
        git=1:2.14.1-1ubuntu4 \
-       vim=2:8.0.0197-4ubuntu5 \
        g++-multilib=4:7.2.0-1ubuntu1 \
        clang-5.0=1:5.0-3 \
        make=4.1-9.1 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -77,6 +77,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -19,7 +19,6 @@ RUN dpkg --add-architecture i386 \
        g++-multilib=4:7.2.0-1ubuntu1 \
        clang-5.0=1:5.0-3 \
        make=4.1-9.1 \
-       valgrind=1:3.13.0-1ubuntu2 \
        libc6-dev-i386=2.26-0ubuntu2.1 \
        libgmp-dev=2:6.1.2+dfsg-1 \
        libmpfr-dev=3.1.6-1 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -53,6 +53,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -qq update \
        sudo=1.8.21p2-3ubuntu1 \
        wget=1.19.4-1ubuntu2 \
        git \
-       vim=2:8.0.1453-1ubuntu1 \
        g++-multilib=4:7.3.0-3ubuntu2 \
        clang-6.0=1:6.0-1ubuntu2 \
        make=4.1-9.1ubuntu1 \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -76,6 +76,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get -qq update \
        g++-multilib=4:7.3.0-3ubuntu2 \
        clang-6.0=1:6.0-1ubuntu2 \
        make=4.1-9.1ubuntu1 \
-       valgrind=1:3.13.0-2ubuntu2 \
        libc6-dev=2.27-3ubuntu1 \
        libgmp-dev=2:6.1.2+dfsg-2 \
        libmpfr-dev=4.0.1-1 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.21p2-3ubuntu1 \
        wget=1.19.4-1ubuntu2 \
        git \
-       vim=2:8.0.1453-1ubuntu1 \
        g++-multilib=4:7.3.0-3ubuntu2 \
        clang-6.0=1:6.0-1ubuntu2 \
        make=4.1-9.1ubuntu1 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -77,6 +77,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -19,7 +19,6 @@ RUN dpkg --add-architecture i386 \
        g++-multilib=4:7.3.0-3ubuntu2 \
        clang-6.0=1:6.0-1ubuntu2 \
        make=4.1-9.1ubuntu1 \
-       valgrind=1:3.13.0-2ubuntu2 \
        libc6-dev-i386=2.27-3ubuntu1 \
        libgmp-dev=2:6.1.2+dfsg-2 \
        libmpfr-dev=4.0.1-1 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -53,6 +53,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -76,6 +76,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get -qq update \
        g++-multilib=4:8.2.0-1ubuntu1 \
        clang-7 \
        make=4.2.1-1.2 \
-       valgrind=1:3.13.0-2ubuntu6 \
        libc6-dev=2.28-0ubuntu1 \
        libgmp-dev=2:6.1.2+dfsg-3 \
        libmpfr-dev=4.0.1-1 \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -qq update \
        sudo=1.8.23-2ubuntu1 \
        wget=1.19.5-1ubuntu1 \
        git \
-       vim=2:8.0.1766-1ubuntu1 \
        g++-multilib=4:8.2.0-1ubuntu1 \
        clang-7 \
        make=4.2.1-1.2 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        sudo=1.8.23-2ubuntu1 \
        wget=1.19.5-1ubuntu1 \
        git \
-       vim=2:8.0.1766-1ubuntu1 \
        g++-multilib=4:8.2.0-1ubuntu1 \
        clang-7\
        make=4.2.1-1.2 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -19,7 +19,6 @@ RUN dpkg --add-architecture i386 \
        g++-multilib=4:8.2.0-1ubuntu1 \
        clang-7\
        make=4.2.1-1.2 \
-       valgrind=1:3.13.0-2ubuntu6 \
        libc6-dev-i386=2.28-0ubuntu1 \
        libgmp-dev=2:6.1.2+dfsg-3 \
        libmpfr-dev=4.0.1-1 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -77,6 +77,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -53,6 +53,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -21,7 +21,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.23-* \
        nasm=2.11.* \
        dh-autoreconf=11 \
-       valgrind=1:3.11.* \
        ninja-build=1.5.*  \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -43,6 +43,9 @@ RUN dpkg --add-architecture i386 \
        && rm -rf /var/lib/apt/lists/* \
        && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
        && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
        && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
        && rm -rf cmake-3.12.1-Linux-x86_64 \
        && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -13,7 +13,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=12.* \
        wget=1.17.* \
        git=1:2.7.* \
-       vim=2:7.4.* \
        libc6-dev-i386=2.23-* \
        g++-multilib=4:5.3.* \
        libgmp-dev=2:6.1.* \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -qq update \
        build-essential=11.* \
        wget=1.13.* \
        git=1:1.7.* \
-       vim=2:7.3.* \
        libc6-dev-i386=2.15-* \
        g++-multilib=4:4.6.* \
        nasm=2.09.* \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -56,6 +56,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get -qq update \
        g++-multilib=4:4.6.* \
        nasm=2.09.* \
        dh-autoreconf=5ubuntu1 \
-       valgrind=1:3.7.* \
        ninja-build=1.3.* \
        libffi-dev=3.0.* \
        libssl-dev=1.* \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -33,6 +33,9 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate -O /tmp/cmake-3.12.1-Linux-x86_64.tar.gz http://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf /tmp/cmake-3.12.1-Linux-x86_64.tar.gz -C /tmp \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR /tmp/cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf /tmp/cmake-3.12.1-Linux-x86_64* \
     && groupadd 1001 -g 1001 \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -60,6 +60,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        git=1:1.9.* \
        nasm=2.10.* \
        dh-autoreconf=9 \
-       valgrind=1:3.10.* \
        ninja-build=1.3.* \
        libffi-dev=3.1* \
        libssl-dev=1.0.* \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -14,7 +14,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=11.* \
        wget=1.15-* \
        git=1:1.9.* \
-       vim=2:7.4.* \
        nasm=2.10.* \
        dh-autoreconf=9 \
        valgrind=1:3.10.* \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -35,6 +35,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -60,6 +60,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 \
        g++-multilib=4:4.8.* \
        nasm=2.10.* \
        dh-autoreconf=9 \
-       valgrind=1:3.10.* \
        ninja-build=1.3.* \
        libffi-dev=3.1* \
        libssl-dev=1.0.* \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=11.* \
        wget=1.15-* \
        git=1:1.9.* \
-       vim=2:7.4.* \
        libc6-dev-i386=2.19-* \
        g++-multilib=4:4.8.* \
        nasm=2.10.* \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -34,6 +34,9 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -58,6 +58,8 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -15,7 +15,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     git=1:2.5.* \
     nasm=2.11.* \
     dh-autoreconf=10 \
-    valgrind=1:3.11.* \
     ninja-build=1.3.* \
     libffi-dev=3.2.* \
     libssl-dev=1.0.2* \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -13,7 +13,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     build-essential=12.* \
     wget=1.16.* \
     git=1:2.5.* \
-    vim=2:7.4.* \
     nasm=2.11.* \
     dh-autoreconf=10 \
     valgrind=1:3.11.* \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -14,7 +14,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     build-essential=12.* \
     wget=1.16.* \
     git=1:2.5.* \
-    vim=2:7.4.* \
     nasm=2.11.* \
     dh-autoreconf=10 \
     libc6:armhf \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -36,6 +36,9 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -60,6 +60,8 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -17,7 +17,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     nasm=2.11.* \
     dh-autoreconf=10 \
     libc6:armhf \
-    valgrind=1:3.11.* \
     ninja-build=1.3.* \
     libffi-dev=3.2.* \
     libssl-dev=1.0.2* \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -19,7 +19,6 @@ RUN dpkg --add-architecture i386 \
        git \
        nasm=2.10.09-1 \
        dh-autoreconf=9 \
-       valgrind=1:3.10.1-1ubuntu3~14.5 \
        ninja-build=1.3.4-1.1ubuntu0.14.04.1 \
        libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.2 \
        libssl-dev=1.* \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -67,6 +67,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -17,7 +17,6 @@ RUN dpkg --add-architecture i386 \
        g++-4.9-multilib=4.9.4-2ubuntu1~14.04.1 \
        wget=1.15-1ubuntu1.14.04.4 \
        git \
-       vim=2:7.4.052-1ubuntu3.1 \
        nasm=2.10.09-1 \
        dh-autoreconf=9 \
        valgrind=1:3.10.1-1ubuntu3~14.5 \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -19,7 +19,6 @@ RUN dpkg --add-architecture i386 \
        git \
        nasm=2.10.09-1 \
        dh-autoreconf=9 \
-       valgrind=1:3.10.1-1ubuntu3~14.5 \
        ninja-build=1.3.4-1.1ubuntu0.14.04.1 \
        libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.2 \
        libssl-dev=1.* \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -42,6 +42,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -17,7 +17,6 @@ RUN dpkg --add-architecture i386 \
        gcc-multilib=4:4.8.2-1ubuntu6 \
        wget=1.15-1ubuntu1.14.04.4 \
        git \
-       vim=2:7.4.052-1ubuntu3.1 \
        nasm=2.10.09-1 \
        dh-autoreconf=9 \
        valgrind=1:3.10.1-1ubuntu3~14.5 \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -67,6 +67,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -qq update \
        build-essential=12.1ubuntu2 \
        wget=1.17.* \
        git=1:2.7.* \
-       vim=2:7.* \
        g++=4:5.3.* \
        libgmp-dev=2:6.1.0+dfsg-2 \
        libmpfr-dev=3.1.4-1 \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get -qq update \
        libc6-dev=2.23* \
        nasm=2.11.08-1 \
        dh-autoreconf=11 \
-       valgrind=1:3.11.0-1ubuntu4.2 \
        ninja-build=1.5.1-0.1ubuntu1  \
        libffi-dev=3.2.1-4 \
        libssl-dev=1.0.2* \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -62,6 +62,8 @@ RUN apt-get -qq update \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \
+       # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
        && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
        && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -59,6 +59,8 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -13,7 +13,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     build-essential=12.* \
     wget=1.16.* \
     git=1:2.5.* \
-    vim=2:7.4.* \
     libc6-dev-i386=2.21-* \
     g++-multilib=4:5.2.* \
     nasm=2.11.* \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -35,6 +35,9 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -17,7 +17,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     g++-multilib=4:5.2.* \
     nasm=2.11.* \
     dh-autoreconf=10 \
-    valgrind=1:3.11.* \
     ninja-build=1.3.* \
     libffi-dev=3.2.* \
     libssl-dev=1.0.2* \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -105,6 +105,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
     && pyenv global 3.7.1 \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=12.* \
        wget=1.17.* \
        git=1:2.7.* \
-       vim=2:7.4.* \
        libc6-dev-i386=2.23-* \
        g++-multilib=4:5.3.* \
        libgmp-dev=2:6.1.* \
@@ -21,7 +20,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.23-* \
        nasm=2.11.* \
        dh-autoreconf=11 \
-       valgrind=1:3.11.* \
     && apt-get -qq install -y --allow-downgrades --no-install-recommends \
        gcc-5=5.3.1-14ubuntu2 \
        gcc-5-base=5.3.1-14ubuntu2 \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -84,6 +84,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -38,6 +38,9 @@ RUN dpkg --add-architecture i386 \
        && rm -rf /var/lib/apt/lists/* \
        && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
        && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
        && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
        && rm -rf cmake-3.12.1-Linux-x86_64 \
        && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -20,7 +20,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.23-* \
        nasm=2.11.* \
        dh-autoreconf=11 \
-       valgrind=1:3.11.* \
        ninja-build=1.5.*  \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -62,6 +62,8 @@ RUN dpkg --add-architecture i386 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \
+       # remove all __pycache__ directories created by pyenv
+       && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
        && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
        && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=12.* \
        wget=1.17.* \
        git=1:2.7.* \
-       vim=2:7.4.* \
        libc6-dev-i386=2.23-* \
        g++-multilib=4:5.3.* \
        libgmp-dev=2:6.1.* \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -20,7 +20,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.23-* \
        nasm=2.11.* \
        dh-autoreconf=11 \
-       valgrind=1:3.11.* \
        ninja-build=1.5.*  \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -62,6 +62,8 @@ RUN dpkg --add-architecture i386 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \
+       # remove all __pycache__ directories created by pyenv
+       && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
        && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
        && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=12.* \
        wget=1.17.* \
        git=1:2.7.* \
-       vim=2:7.4.* \
        libc6-dev-i386=2.23-* \
        g++-multilib=4:5.3.* \
        libgmp-dev=2:6.1.* \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -38,6 +38,9 @@ RUN dpkg --add-architecture i386 \
        && rm -rf /var/lib/apt/lists/* \
        && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
        && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+          --exclude=bin/cmake-gui \
+          --exclude=doc/cmake \
+          --exclude=share/cmake-3.12/Help \
        && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
        && rm -rf cmake-3.12.1-Linux-x86_64 \
        && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -qq update \
        binutils=2.29.* \
        wget=1.19.* \
        git=1:2.* \
-       vim=2:8.* \
        libc6-dev=2.26* \
        linux-libc-dev=4.13* \
        g++-6=6.4.* \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -69,6 +69,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get -qq update \
        libc6-dev=2.26-0ubuntu2.1 \
        nasm=2.13.01-2 \
        dh-autoreconf=14 \
-       valgrind=1:3.13.0-1ubuntu3 \
        ninja-build=1.7.2-3 \
        libffi-dev=3.2.1-6 \
        libssl-dev=1.0.2* \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -22,7 +22,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.24-* \
        nasm=2.12.* \
        dh-autoreconf=12 \
-       valgrind=1:3.12.* \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -14,7 +14,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=12.* \
        wget=1.18-* \
        git=1:2.9.* \
-       vim=2:7.4.* \
        libc6-dev-i386=2.24-* \
        g++-multilib=4:6.1.* \
        libgmp-dev=2:6.1.* \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -40,6 +40,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -64,6 +64,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -22,7 +22,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.24* \
        nasm=2.12.* \
        dh-autoreconf=13 \
-       valgrind=1:3.* \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.* \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -14,7 +14,6 @@ RUN dpkg --add-architecture i386 \
        build-essential=12.1* \
        wget=1.18* \
        git=1:2.* \
-       vim=2:8.* \
        libc6-dev-i386=2.24* \
        g++-multilib=4:6.3.* \
        libgmp-dev=2:6.* \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -40,6 +40,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -64,6 +64,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        binutils=2.29.* \
        wget=1.19.* \
        git=1:2.14.* \
-       vim=2:8.0.* \
        libc6-dev-i386=2.26-* \
        linux-libc-dev:i386=4.13.* \
        g++-6-multilib=6.4.* \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -67,6 +67,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -43,6 +43,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -21,7 +21,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.26* \
        nasm=2.13.* \
        dh-autoreconf=14 \
-       valgrind=1:3.13.* \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        binutils=2.29.* \
        wget=1.19.* \
        git=1:2.14.* \
-       vim=2:8.0.* \
        libc6-dev-i386=2.26-* \
        linux-libc-dev:i386=4.13.* \
        g++-6-multilib=6.4.* \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -44,6 +44,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -68,6 +68,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -21,7 +21,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.26* \
        nasm=2.13.* \
        dh-autoreconf=14 \
-       valgrind=1:3.13.* \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -81,7 +81,8 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \
     && printf "conan:conan" | chpasswd \
-    && chown -R conan:1001 /opt/pyenv
+    && chown -R conan:1001 /opt/pyenv \
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf
 
 USER conan
 WORKDIR /home/conan

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -21,7 +21,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
        wget \
        git \
        make \
-       valgrind \
        glibc-devel \
        gmp-devel \
        mpfr-devel \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -18,7 +18,6 @@ RUN yum update -y \
        wget \
        git \
        make \
-       valgrind \
        glibc-devel \
        glibc-devel.i686 \
        libgcc.i686 \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -69,6 +69,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get -qq update \
        libc6-dev=2.26-0ubuntu2.1 \
        nasm=2.13.01-2 \
        dh-autoreconf=14 \
-       valgrind=1:3.13.0-1ubuntu3 \
        ninja-build=1.7.2-3 \
        libffi-dev=3.2.1-6 \
        libssl-dev=1.0.2* \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -qq update \
        binutils=2.29.* \
        wget=1.19.* \
        git=1:2.* \
-       vim=2:8.* \
        libc6-dev=2.26-* \
        linux-libc-dev=4.13.* \
        g++-7=7.2.* \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        binutils=2.29.* \
        wget=1.19.* \
        git=1:2.14.* \
-       vim=2:8.0.* \
        libc6-dev-i386=2.26-* \
        linux-libc-dev:i386=4.13.* \
        g++-7-multilib=7.2.* \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -65,6 +65,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -41,6 +41,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -21,7 +21,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.26* \
        nasm=2.13.* \
        dh-autoreconf=14 \
-       valgrind=1:3.13.* \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -42,6 +42,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        binutils=2.29.* \
        wget=1.19.* \
        git=1:2.14.* \
-       vim=2:8.0.* \
        libc6-dev-i386=2.26-* \
        linux-libc-dev:i386=4.13.* \
        g++-7-multilib=7.2.* \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -66,6 +66,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -21,7 +21,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.26* \
        nasm=2.13.* \
        dh-autoreconf=14 \
-       valgrind=1:3.13.* \
        ninja-build=1.7.* \
        libffi-dev=3.2.* \
        libssl-dev=1.0.2* \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get -qq update \
        libc6-dev=2.27-3ubuntu1 \
        nasm=2.13.02-0.1 \
        dh-autoreconf=17 \
-       valgrind=1:3.13.0-2ubuntu2 \
        ninja-build=1.8.2-1 \
        libffi-dev=3.2.1-8 \
        libssl-dev=1.* \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -69,6 +69,8 @@ RUN apt-get -qq update \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -qq update \
        binutils=2.* \
        wget=1.19.4-1ubuntu2.1 \
        git=1:2.* \
-       vim=2:8.0.1453-1ubuntu1 \
        libc6-dev=2.27-3ubuntu1 \
        linux-libc-dev=4.* \
        g++-8 \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -44,6 +44,9 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* \
     && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
     && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
     && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
     && rm -rf cmake-3.12.1-Linux-x86_64 \
     && rm cmake-3.12.1-Linux-x86_64.tar.gz \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -68,6 +68,8 @@ RUN dpkg --add-architecture i386 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -21,7 +21,6 @@ RUN dpkg --add-architecture i386 \
        libc6-dev=2.27-3ubuntu1 \
        nasm=2.13.02-0.1 \
        dh-autoreconf=17 \
-       valgrind=1:3.13.0-2ubuntu2 \
        ninja-build=1.8.2-1 \
        libffi-dev=3.2.1-8 \
        libssl-dev=1.* \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -12,7 +12,6 @@ RUN dpkg --add-architecture i386 \
        binutils=2.* \
        wget=1.19.4-1ubuntu2.1 \
        git=1:2.* \
-       vim=2:8.0.1453-1ubuntu1 \
        libc6-dev-i386=2.27-3ubuntu1 \
        linux-libc-dev:i386=4.* \
        g++-8-multilib \


### PR DESCRIPTION
fixes https://github.com/conan-io/conan-docker-tools/issues/89

- output image size during the build
- do not install valgrind
- do not install vim (this also avoids python 3.6 installation)
- exclude CMake GUI & docs during untargz
- remove `__pycache__` directories

for GCC 6 image, effect is: `1.02 GB` -> `734.36 MB`

/cc @uilianries @lasote @memsharded @jgsogo @danimtb 