### PR TITLE
Fix sudo script in gcc_7-centos6 and gcc_7-centos6-x86

### DIFF
--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -85,6 +85,10 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && chown -R conan:1001 /opt/pyenv \
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf
 
+# Fix sudo with arguments: https://bugzilla.redhat.com/show_bug.cgi?id=1319936
+COPY sudo /opt/rh/devtoolset-7/root/usr/bin/sudo
+RUN chmod a+x /opt/rh/devtoolset-7/root/usr/bin/sudo
+
 USER conan
 WORKDIR /home/conan
 

--- a/gcc_7-centos6-x86/sudo
+++ b/gcc_7-centos6-x86/sudo
@@ -1,0 +1,32 @@
+#! /bin/sh
+cmd_started=false
+is_option_param_next=false
+for arg in "$@"
+do
+   case "$arg" in
+    *\'*)
+      arg= ;;
+   esac
+   if [ "$cmd_started" = true ]; then
+       cmd_options="$cmd_options '$arg'"
+   elif [ "$is_option_param_next" = true ]; then
+       sudo_options="$sudo_options $arg"
+       is_option_param_next=false
+   elif [[ $arg == -* ]]; then
+       sudo_options="$sudo_options $arg"
+       case "$arg" in
+        "-g" | "-h" | "-p" | "-u" | "-U" | "-C" | "-i" | "-s")
+          is_option_param_next=true
+        ;;
+       esac
+   elif [[ $arg == *=* ]]; then
+       sudo_options="$sudo_options $arg"
+   else
+       cmd_options="$cmd_options '$arg'"
+       cmd_started=true
+   fi
+done
+if [ "$sudo_options" == "" ]; then
+    sudo_options="-E"
+fi
+exec /usr/bin/sudo $sudo_options LD_LIBRARY_PATH=$LD_LIBRARY_PATH PATH=$PATH scl enable devtoolset-7 "$cmd_options"

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -51,6 +51,10 @@ RUN yum update -y \
     && chgrp -R wheel /opt/rh/rh-python36/root \
     && chmod -R g+w -R /opt/rh/rh-python36/root
 
+# Fix sudo with arguments: https://bugzilla.redhat.com/show_bug.cgi?id=1319936
+COPY sudo /opt/rh/devtoolset-7/root/usr/bin/sudo
+RUN chmod a+x /opt/rh/devtoolset-7/root/usr/bin/sudo
+
 USER conan
 WORKDIR /home/conan
 

--- a/gcc_7-centos6/sudo
+++ b/gcc_7-centos6/sudo
@@ -1,0 +1,32 @@
+#! /bin/sh
+cmd_started=false
+is_option_param_next=false
+for arg in "$@"
+do
+   case "$arg" in
+    *\'*)
+      arg= ;;
+   esac
+   if [ "$cmd_started" = true ]; then
+       cmd_options="$cmd_options '$arg'"
+   elif [ "$is_option_param_next" = true ]; then
+       sudo_options="$sudo_options $arg"
+       is_option_param_next=false
+   elif [[ $arg == -* ]]; then
+       sudo_options="$sudo_options $arg"
+       case "$arg" in
+        "-g" | "-h" | "-p" | "-u" | "-U" | "-C" | "-i" | "-s")
+          is_option_param_next=true
+        ;;
+       esac
+   elif [[ $arg == *=* ]]; then
+       sudo_options="$sudo_options $arg"
+   else
+       cmd_options="$cmd_options '$arg'"
+       cmd_started=true
+   fi
+done
+if [ "$sudo_options" == "" ]; then
+    sudo_options="-E"
+fi
+exec /usr/bin/sudo $sudo_options LD_LIBRARY_PATH=$LD_LIBRARY_PATH PATH=$PATH scl enable devtoolset-7 "$cmd_options"


### PR DESCRIPTION
Fixes conan-io/conan-docker-tools#105

Tested on my local machine:
```
$ docker build --no-cache  -t conanio/gcc7-centos6_myversion .
$ docker run -t -i --rm -v /tmp:/home/conan/project:Z conanio/gcc7-centos6_myversion /bin/bash
[conan@48c653b979fa ~]$ sudo -A ls
project
```
