### PR TITLE
Fix Conan Server image

### DIFF
--- a/conan_server/Dockerfile
+++ b/conan_server/Dockerfile
@@ -7,12 +7,14 @@ ENV CONAN_VERSION=${CONAN_VERSION}
 
 ADD https://github.com/conan-io/conan/archive/${CONAN_VERSION}.zip /
 
-RUN unzip ${CONAN_VERSION} \
+RUN apk add --no-cache gcc libc-dev \
+    && unzip ${CONAN_VERSION} \
     && rm ${CONAN_VERSION}.zip \
     && cd conan-${CONAN_VERSION} \
     && pip3 install -r conans/requirements.txt \
     && pip3 install -r conans/requirements_server.txt \
-    && pip3 install gunicorn
+    && pip3 install gunicorn \
+    && apk del gcc libc-dev
 
 EXPOSE 9300
 


### PR DESCRIPTION
- The typed-ast 1.3.0 requires gcc to be built.

The package is built and all compiler stuff is removed.

The image size now is 121MB (inflated), +5MB than 1.12.3
