### PR TITLE
Feature/armv8: Add Dockerfiles for armv8 architecture, from gcc5 to gcc8.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,24 +83,36 @@ jobs:
       Ubuntu GCC 5 armv7hf:
         GCC_VERSIONS: "5"
         DOCKER_ARCHS: "x86_64,armv7hf"
+      Ubuntu GCC 5 armv8:
+        GCC_VERSIONS: "5"
+        DOCKER_ARCHS: "x86_64,armv8"
       Ubuntu GCC 6 armv7:
         GCC_VERSIONS: "6"
         DOCKER_ARCHS: "x86_64,armv7"
       Ubuntu GCC 6 armv7hf:
         GCC_VERSIONS: "6"
         DOCKER_ARCHS: "x86_64,armv7hf"
+      Ubuntu GCC 6 armv8:
+        GCC_VERSIONS: "6"
+        DOCKER_ARCHS: "x86_64,armv8"
       Ubuntu GCC 7 armv7:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64,armv7"
       Ubuntu GCC 7 armv7hf:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64,armv7hf"
+      Ubuntu GCC 7 armv8:
+        GCC_VERSIONS: "7"
+        DOCKER_ARCHS: "x86_64,armv8"
       Ubuntu GCC 8 armv7:
         GCC_VERSIONS: "8"
         DOCKER_ARCHS: "x86_64,armv7"
       Ubuntu GCC 8 armv7hf:
         GCC_VERSIONS: "8"
         DOCKER_ARCHS: "x86_64,armv7hf"
+      Ubuntu GCC 8 armv8:
+        GCC_VERSIONS: "8"
+        DOCKER_ARCHS: "x86_64,armv8"
 
       Ubuntu Clang 3.8 x86_64:
         CLANG_VERSIONS: "3.8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,13 @@ services:
         image: "${DOCKER_USERNAME}/gcc5-armv7hf:${DOCKER_BUILD_TAG}"
         container_name: gcc5-armv7hf
         tty: true
+    gcc5-armv8:
+        build:
+            context: gcc_5-armv8
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/gcc5-armv8:${DOCKER_BUILD_TAG}"
+        container_name: gcc5-armv8
+        tty: true
     gcc52:
         build:
             context: gcc_5.2
@@ -126,6 +133,13 @@ services:
         image: "${DOCKER_USERNAME}/gcc6-armv7hf:${DOCKER_BUILD_TAG}"
         container_name: gcc6-armv7hf
         tty: true
+    gcc6-armv8:
+        build:
+            context: gcc_6-armv8
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/gcc6-armv8:${DOCKER_BUILD_TAG}"
+        container_name: gcc6-armv8
+        tty: true
     gcc63:
         build:
             context: gcc_6.3
@@ -168,6 +182,13 @@ services:
         image: "${DOCKER_USERNAME}/gcc7-armv7hf:${DOCKER_BUILD_TAG}"
         container_name: gcc7-armv7hf
         tty: true
+    gcc7-armv8:
+        build:
+            context: gcc_7-armv8
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/gcc7-armv8:${DOCKER_BUILD_TAG}"
+        container_name: gcc7-armv8
+        tty: true
     gcc7-mingw:
         build:
             context: gcc_7-mingw
@@ -209,6 +230,13 @@ services:
             dockerfile: Dockerfile
         image: "${DOCKER_USERNAME}/gcc8-armv7hf:${DOCKER_BUILD_TAG}"
         container_name: gcc8-armv7hf
+        tty: true
+    gcc8-armv8:
+        build:
+            context: gcc_8-armv8
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/gcc8-armv8:${DOCKER_BUILD_TAG}"
+        container_name: gcc8-armv8
         tty: true
     clang38:
         build:

--- a/gcc_5-armv8/.dockerignore
+++ b/gcc_5-armv8/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/gcc_5-armv8/Dockerfile
+++ b/gcc_5-armv8/Dockerfile
@@ -2,7 +2,6 @@ FROM conanio/gcc5
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-
 ENV CC=aarch64-linux-gnu-gcc-5 \
     CXX=aarch64-linux-gnu-g++-5 \
     CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-5 \
@@ -14,14 +13,18 @@ ENV CC=aarch64-linux-gnu-gcc-5 \
     LD=aarch64-linux-gnu-ld \
     FC=aarch64-linux-gnu-gfortran-5
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get install -y --no-install-recommends \
+COPY arm64.list /etc/apt/sources.list.d/arm64.list
+
+RUN sudo dpkg --add-architecture arm64 \
+    && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
+    && sudo apt-get -qq update \
+    && sudo apt-get install -y --force-yes --no-install-recommends \
        ".*5.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-5 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-5 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-5 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-5 100 \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && pip install -q conan conan-package-tools --upgrade \
+    && pip install -q --no-cache-dir conan conan-package-tools --upgrade \
     && conan profile new default --detect \
     && conan profile update settings.arch=armv8 default

--- a/gcc_5-armv8/Dockerfile
+++ b/gcc_5-armv8/Dockerfile
@@ -1,0 +1,27 @@
+FROM conanio/gcc5
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+
+ENV CC=aarch64-linux-gnu-gcc-5 \
+    CXX=aarch64-linux-gnu-g++-5 \
+    CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-5 \
+    CMAKE_CXX_COMPILER=aarch64-linux-gnu-g++-5 \
+    STRIP=aarch64-linux-gnu-strip \
+    RANLIB=aarch64-linux-gnu-ranlib \
+    AS=aarch64-linux-gnu-as \
+    AR=aarch64-linux-gnu-ar \
+    LD=aarch64-linux-gnu-ld \
+    FC=aarch64-linux-gnu-gfortran-5
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+       ".*5.*aarch64-linux-gnu.*" \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-5 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-5 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-5 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-5 100 \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && pip install -q conan conan-package-tools --upgrade \
+    && conan profile new default --detect \
+    && conan profile update settings.arch=armv8 default

--- a/gcc_5-armv8/Dockerfile
+++ b/gcc_5-armv8/Dockerfile
@@ -18,7 +18,7 @@ COPY arm64.list /etc/apt/sources.list.d/arm64.list
 RUN sudo dpkg --add-architecture arm64 \
     && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
     && sudo apt-get -qq update \
-    && sudo apt-get install -y --force-yes --no-install-recommends \
+    && sudo apt-get install -y --no-install-recommends \
        ".*5.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-5 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-5 100 \

--- a/gcc_5-armv8/arm64.list
+++ b/gcc_5-armv8/arm64.list
@@ -1,0 +1,4 @@
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted universe multiverse

--- a/gcc_6-armv8/.dockerignore
+++ b/gcc_6-armv8/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/gcc_6-armv8/Dockerfile
+++ b/gcc_6-armv8/Dockerfile
@@ -18,7 +18,7 @@ COPY arm64.list /etc/apt/sources.list.d/arm64.list
 RUN sudo dpkg --add-architecture arm64 \
     && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
     && sudo apt-get -qq update \
-    && sudo apt-get install -y --force-yes --no-install-recommends \
+    && sudo apt-get install -y --no-install-recommends \
        ".*6.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-6 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-6 100 \

--- a/gcc_6-armv8/Dockerfile
+++ b/gcc_6-armv8/Dockerfile
@@ -1,0 +1,28 @@
+FROM conanio/gcc6
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+
+ENV CC=aarch64-linux-gnu-gcc-6 \
+    CXX=aarch64-linux-gnu-g++-6 \
+    CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-6 \
+    CMAKE_CXX_COMPILER=aarch64-linux-gnu-g++-6 \
+    STRIP=aarch64-linux-gnu-strip \
+    RANLIB=aarch64-linux-gnu-ranlib \
+    AS=aarch64-linux-gnu-as \
+    AR=aarch64-linux-gnu-ar \
+    LD=aarch64-linux-gnu-ld \
+    FC=aarch64-linux-gnu-gfortran-6
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+       ".*6.*aarch64-linux-gnu.*" \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-6 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-6 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-6 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-6 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-6 100 \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && pip install -q conan conan-package-tools --upgrade \
+    && conan profile new default --detect \
+    && conan profile update settings.arch=armv8 default

--- a/gcc_6-armv8/Dockerfile
+++ b/gcc_6-armv8/Dockerfile
@@ -2,7 +2,6 @@ FROM conanio/gcc6
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-
 ENV CC=aarch64-linux-gnu-gcc-6 \
     CXX=aarch64-linux-gnu-g++-6 \
     CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-6 \
@@ -14,8 +13,12 @@ ENV CC=aarch64-linux-gnu-gcc-6 \
     LD=aarch64-linux-gnu-ld \
     FC=aarch64-linux-gnu-gfortran-6
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get install -y --no-install-recommends \
+COPY arm64.list /etc/apt/sources.list.d/arm64.list
+
+RUN sudo dpkg --add-architecture arm64 \
+    && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
+    && sudo apt-get -qq update \
+    && sudo apt-get install -y --force-yes --no-install-recommends \
        ".*6.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-6 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-6 100 \
@@ -23,6 +26,6 @@ RUN sudo apt-get -qq update \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-6 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-6 100 \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && pip install -q conan conan-package-tools --upgrade \
+    && pip install -q --no-cache-dir conan conan-package-tools --upgrade \
     && conan profile new default --detect \
     && conan profile update settings.arch=armv8 default

--- a/gcc_6-armv8/arm64.list
+++ b/gcc_6-armv8/arm64.list
@@ -1,0 +1,4 @@
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful-backports main restricted universe multiverse

--- a/gcc_7-armv8/.dockerignore
+++ b/gcc_7-armv8/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/gcc_7-armv8/Dockerfile
+++ b/gcc_7-armv8/Dockerfile
@@ -1,0 +1,28 @@
+FROM conanio/gcc7
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+
+ENV CC=aarch64-linux-gnu-gcc-7 \
+    CXX=aarch64-linux-gnu-g++-7 \
+    CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-7 \
+    CMAKE_CXX_COMPILER=aarch64-linux-gnu-g++-7 \
+    STRIP=aarch64-linux-gnu-strip \
+    RANLIB=aarch64-linux-gnu-ranlib \
+    AS=aarch64-linux-gnu-as \
+    AR=aarch64-linux-gnu-ar \
+    LD=aarch64-linux-gnu-ld \
+    FC=aarch64-linux-gnu-gfortran-7
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+       ".*7.*aarch64-linux-gnu.*" \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-7 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-7 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-7 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-7 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-7 100 \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && pip install -q conan conan-package-tools --upgrade \
+    && conan profile new default --detect \
+    && conan profile update settings.arch=armv8 default

--- a/gcc_7-armv8/Dockerfile
+++ b/gcc_7-armv8/Dockerfile
@@ -2,7 +2,6 @@ FROM conanio/gcc7
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-
 ENV CC=aarch64-linux-gnu-gcc-7 \
     CXX=aarch64-linux-gnu-g++-7 \
     CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-7 \
@@ -14,8 +13,12 @@ ENV CC=aarch64-linux-gnu-gcc-7 \
     LD=aarch64-linux-gnu-ld \
     FC=aarch64-linux-gnu-gfortran-7
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get install -y --no-install-recommends \
+COPY arm64.list /etc/apt/sources.list.d/arm64.list
+
+RUN sudo dpkg --add-architecture arm64 \
+    && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
+    && sudo apt-get -qq update \
+    && sudo apt-get install -y --force-yes --no-install-recommends \
        ".*7.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-7 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-7 100 \
@@ -23,6 +26,6 @@ RUN sudo apt-get -qq update \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-7 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-7 100 \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && pip install -q conan conan-package-tools --upgrade \
+    && pip install -q --no-cache-dir conan conan-package-tools --upgrade \
     && conan profile new default --detect \
     && conan profile update settings.arch=armv8 default

--- a/gcc_7-armv8/Dockerfile
+++ b/gcc_7-armv8/Dockerfile
@@ -18,7 +18,7 @@ COPY arm64.list /etc/apt/sources.list.d/arm64.list
 RUN sudo dpkg --add-architecture arm64 \
     && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
     && sudo apt-get -qq update \
-    && sudo apt-get install -y --force-yes --no-install-recommends \
+    && sudo apt-get install -y --no-install-recommends \
        ".*7.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-7 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-7 100 \

--- a/gcc_7-armv8/arm64.list
+++ b/gcc_7-armv8/arm64.list
@@ -1,0 +1,4 @@
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ artful-backports main restricted universe multiverse

--- a/gcc_8-armv8/.dockerignore
+++ b/gcc_8-armv8/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/gcc_8-armv8/Dockerfile
+++ b/gcc_8-armv8/Dockerfile
@@ -18,7 +18,7 @@ COPY arm64.list /etc/apt/sources.list.d/arm64.list
 RUN sudo dpkg --add-architecture arm64 \
     && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
     && sudo apt-get -qq update \
-    && sudo apt-get install -y --force-yes --no-install-recommends \
+    && sudo apt-get install -y --no-install-recommends \
        ".*8.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-8 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-8 100 \

--- a/gcc_8-armv8/Dockerfile
+++ b/gcc_8-armv8/Dockerfile
@@ -2,7 +2,6 @@ FROM conanio/gcc8
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-
 ENV CC=aarch64-linux-gnu-gcc-8 \
     CXX=aarch64-linux-gnu-g++-8 \
     CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-8 \
@@ -14,8 +13,12 @@ ENV CC=aarch64-linux-gnu-gcc-8 \
     LD=aarch64-linux-gnu-ld \
     FC=aarch64-linux-gnu-gfortran-8
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get install -y --no-install-recommends \
+COPY arm64.list /etc/apt/sources.list.d/arm64.list
+
+RUN sudo dpkg --add-architecture arm64 \
+    && sudo sed -i 's/deb\s/deb \[arch=amd64,i386\] /' /etc/apt/sources.list \
+    && sudo apt-get -qq update \
+    && sudo apt-get install -y --force-yes --no-install-recommends \
        ".*8.*aarch64-linux-gnu.*" \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-8 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-8 100 \
@@ -23,6 +26,6 @@ RUN sudo apt-get -qq update \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-8 100 \
     && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-8 100 \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && pip install -q conan conan-package-tools --upgrade \
+    && pip install -q --no-cache-dir conan conan-package-tools --upgrade \
     && conan profile new default --detect \
     && conan profile update settings.arch=armv8 default

--- a/gcc_8-armv8/Dockerfile
+++ b/gcc_8-armv8/Dockerfile
@@ -1,0 +1,28 @@
+FROM conanio/gcc8
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+
+ENV CC=aarch64-linux-gnu-gcc-8 \
+    CXX=aarch64-linux-gnu-g++-8 \
+    CMAKE_C_COMPILER=aarch64-linux-gnu-gcc-8 \
+    CMAKE_CXX_COMPILER=aarch64-linux-gnu-g++-8 \
+    STRIP=aarch64-linux-gnu-strip \
+    RANLIB=aarch64-linux-gnu-ranlib \
+    AS=aarch64-linux-gnu-as \
+    AR=aarch64-linux-gnu-ar \
+    LD=aarch64-linux-gnu-ld \
+    FC=aarch64-linux-gnu-gfortran-8
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+       ".*8.*aarch64-linux-gnu.*" \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-8 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-8 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-8 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-dump aarch64-linux-gnu-gcov-dump /usr/bin/aarch64-linux-gnu-gcov-dump-8 100 \
+    && sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcov-tool aarch64-linux-gnu-gcov-tool /usr/bin/aarch64-linux-gnu-gcov-tool-8 100 \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && pip install -q conan conan-package-tools --upgrade \
+    && conan profile new default --detect \
+    && conan profile update settings.arch=armv8 default

--- a/gcc_8-armv8/arm64.list
+++ b/gcc_8-armv8/arm64.list
@@ -1,0 +1,4 @@
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic-backports main restricted universe multiverse


### PR DESCRIPTION
A single issue occured during gcc5 build, where update-alternatives to /usr/bin/aarch64-linux-gnu-gcov-dump-5 couldn't find the executable even after installing the gcc-5-aarch64-linux-gnu package. The offending line line was simply removed. @SSE4 please let me know if this is acceptable and I will update the README.md.

On each gcc version I locally run the following, without any issues:
```
docker run -ti conanio/gcc*-armv8 bash -c "conan install lz4/1.8.3@bincrafters/stable --build missing"
```

This addresses #109 