### PR TITLE
Add Template for Github issues ***NO_CI***

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+Contributing to Conan Package Tools
+===================================
+
+The following summarizes the process for contributing to the Conan Docker Tools project.
+
+Community
+---------
+
+Conan Docker Tools is an Open Source MIT licensed project.
+Conan Docker Tools is developed by the Conan maintainers and a great community of contributors.
+
+Dev-flow & Pull Requests
+------------------------
+
+CDT (Conan Docker Tools) follows the ["GitFlow"](https://datasift.github.io/gitflow/IntroducingGitFlow.html) branching model.
+Issues are triaged and categorized mainly by type (feature, bug...) complexity (high, medium...) and priority (high, medium...) using GitHub
+ labels. Then they are moved to a stage called "queue" when they are considered to be ready for implementation.
+
+To contribute follow the next steps:
+
+1. Comment in the corresponding issue that you want to contribute the feature/fix proposed. If there is no open issue, we strongly suggest
+   to open one to gather feedback.
+2. Check that the issue has been staged to "queue" or ask @conan-io/barbarians to do it. This helps in terms of validation and discussion of
+   possible implementation of the feature/fix.
+3. Fork the [CDT main repository](https://github.com/conan-io/conan-docker-tools) and create a `feature/xxx` branch from the `master` branch and develop
+   your fix/feature as discussed in previous step.
+4. Try to keep your branch updated with the `master` branch to avoid conflicts.
+5. Open a pull request, and select `master` as the base branch.
+6. Add the text (besides other comments): "fixes #IssueNumber" in the body of the PR, referring to the issue of step 1.
+
+The ``conan-io`` organization maintainers will review and help with the coding of tests. Finally, it will be assigned to milestone.
+
+When the branch is ready, it will be merged into `master` branch. The images are tagged based on latest Conan version.
+
+Issues
+------
+
+If you think you found a bug in CDT open an issue indicating the following:
+
+- Explain the Conan version, CDT image name, Operating System and any other tool that could be related to the issue.
+- Explain, as detailed as possible, how to reproduce the issue. Use git repos to contain code/recipes to reproduce issues.
+- Include the expected behavior as well as what actually happened.
+- Provide output captures (as text).
+- Feel free to attach a screenshot or video illustrating the issue if you think it will be helpful.
+
+For any suggestion, feature request or question open an issue indicating the following:
+
+- Questions and support requests are always welcome.
+- Use the [question] or [suggestion] tags in the title.
+- Try to explain the motivation, what are you trying to do, what is the pain it tries to solve.
+- What do you expect from Conan.
+
+We use the following tags to control the status of the issues:
+
+- **triaging**: Issue is being considered or under discussion. Maintainers are trying to understand the use case or gathering the necessary
+  information.
+- **queue**: Issue has been categorized and is ready to be done in a following release (not necessarily in the next one).
+- **in-progress**: A milestone has previously been assigned to the issue and is now under development.
+- **review**: Issue has a PR associated that solves it (remember to use the GitHub keywords "closes #IssueNumber", "fixes #IssueNumber"...
+  in the description of the PR).
+- **closed via PR**: A PR with the fix or new feature has been merged to `develop` and the issue will be fixed in the next monthly release.
+
+Code of conduct
+---------------
+
+Try to be polite, Conan maintainers and contributors are really willing to help and we enjoy it.
+
+Please keep in mind these points:
+
+- There are limited resources/time and not all issues/pull requests can be considered as well as we would like.
+- ``conan-io`` maintainers can tag/close/modify any opened issue and it should not be interpreted as a rude or disrespectful action. It
+  **always** responds to organizational purposes. A closed issue can be perfectly reopened or further commented.
+- It is very hard to keep the project in good health in terms of technical debt, usability, serviceability, etc. If the proposed feature is
+  not clearly stated, enough information is not provided or it is not sure that would be a good feature for the future development of the
+  project, it won't be accepted. The community plays a very important role during this discussion so it strongly encouraged to
+  explain the value of a feature for the community, the needed documentation and its use cases.
+- Backwards compatibility and not breaking users' packages is very important and it won't be done unless there are very good reasons.
+- You should not get bothered if you feel unattended, Conan is an Open Source project, not a commercial product. Try to explain what you
+  really need and we will try to help you.
+
+Code style
+----------
+
+- In general, follow [pep8](https://www.python.org/dev/peps/pep-0008/) and [Dockerfile Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+- Limit all Python lines to a maximum of 101 characters (`Right margin` setting in PyCharm)
+- Write unit tests, if possible

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Description of Problem, Request, or Question
+
+### Environment Details
+* Conan Docker Tools image: **conanio/gcc7:1.13.1**
+* Operating System: **Linux**
+* Operation System Version: **Ubuntu 16.04**
+* Python version (If you are building some image): **python 3.7.0**
+
+### Steps to reproduce (Include if Applicable)
+
+### Build logs (Include if Available)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Changelog: (Feature | Fix | Bugfix): Describe here your pull request
+
+- [ ] Refer to the issue that supports this Pull Request.
+- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
+- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
+- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
+- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,98 @@
+# https://github.com/apps/settings
+
+repository:
+  has_wiki: false
+  default_branch: master
+
+# Labels: define labels for Issues and Pull Requests
+# colors from: https://htmlcolorcodes.com/color-chart/
+labels:
+  - name: "type: question"
+    color: FADBD8
+    old_name: "question"
+  - name: "type: engineering"
+    color: F5B7B1
+  - name: "type: feature"
+    color: EC7063
+    old_name: "feature"
+  - name: "type: look into"
+    color: CB4335
+    old_name: "look into"
+  - name: "type: bug"
+    color: 943126
+    old_name: "bug"
+
+  - name: "complex: low"
+    color: A3E4D7
+  - name: "complex: medium"
+    color: 48C9B0
+  - name: "complex: high"
+    color: 17A589
+  - name: "complex: huge"
+    color: 117864
+
+  - name: "priority: low"
+    color: F9E79F
+  - name: "priority: medium"
+    color: F4D03F
+  - name: "priority: high"
+    color: D4AC0D
+  - name: "priority: critical"
+    color: 9A7D0A
+
+  - name: "component: artifactory"
+    color: F4ECF7
+  - name: "component: bintray"
+    color: E8DAEF
+  - name: "component: docker"
+    color: D2B4DE
+  - name: "component: CI"
+    description: Only affects CI
+    color: BB8FCE
+  - name: "component: server"
+    color: A569BD
+  - name: "component: hook"
+    color: 8E44AD
+  - name: "component: build"
+    color: 7D3C98
+    old_name: "component: Build"
+    description: Build helpers, build systems...
+  - name: "component: scm"
+    color: 6C3483
+  - name: "component: UX"
+    color: 5B2C6F
+    old_name: "UX"
+    description: No change in business logic
+
+  - name: "stage: triaging"
+    color: E5E7E9
+  - name: "stage: queue"
+    color: CACFD2
+  - name: "stage: in-progress"
+    color: A6ACAF
+    old_name: "in progress"
+  - name: "stage: review"
+    color: 797D7F
+    old_name: "in review"
+
+  - name: "good first issue"
+    color: ABEBC6
+  - name: "help wanted"
+    color: 58D68D
+  - name: "Feedback please!"
+    color: 28B463
+  - name: "feature approved"
+    color: 1D8348
+  - name: "whiteboard"
+    color: FDFEFE
+    description: Needs discussion
+
+  - name: "duplicate"
+    color: ABB2B9
+    description: This was already reported
+  - name: "inactive"
+    color: 566573
+    description: No comments for a long time
+  - name: "obsolete"
+    color: 273746
+    description: Implementation will follow another direction

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 3650
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
- Add Contributing guide from CPT
- Add issues template from CPT
- Add issues labels from CPT

TIL: [How to skip CI on Azure DevOps](https://github.com/Microsoft/azure-pipelines-agent/issues/858#issuecomment-475768046)

EDIT: `***NO_CI***` does not work!