### PR TITLE
define a custom profile instead of default

### DIFF
--- a/android-clang_8-armv7/Dockerfile
+++ b/android-clang_8-armv7/Dockerfile
@@ -17,7 +17,7 @@ ENV ANDROID_ABI=armeabi-v7a \
     OBJDUMP=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-objdump \
     READELF=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-readelf
 
-RUN conan profile update settings.arch=armv7 default \
-    && conan profile update settings.os=Android default \
-    && conan profile update settings.os.api_level=16 default \
-    && conan profile update settings.compiler.libcxx=libc++ default
+RUN conan profile update settings.arch=armv7 $CONAN_BASE_PROFILE \
+    && conan profile update settings.os=Android $CONAN_BASE_PROFILE \
+    && conan profile update settings.os.api_level=16 $CONAN_BASE_PROFILE \
+    && conan profile update settings.compiler.libcxx=libc++ $CONAN_BASE_PROFILE

--- a/android-clang_8-armv8/Dockerfile
+++ b/android-clang_8-armv8/Dockerfile
@@ -16,7 +16,7 @@ ENV ANDROID_ABI=arm64-v8a \
     OBJDUMP=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-objdump \
     READELF=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-readelf
 
-RUN conan profile update settings.arch=armv8 default \
-    && conan profile update settings.os=Android default \
-    && conan profile update settings.os.api_level=21 default \
-    && conan profile update settings.compiler.libcxx=libc++ default
+RUN conan profile update settings.arch=armv8 $CONAN_BASE_PROFILE \
+    && conan profile update settings.os=Android $CONAN_BASE_PROFILE \
+    && conan profile update settings.os.api_level=21 $CONAN_BASE_PROFILE \
+    && conan profile update settings.compiler.libcxx=libc++ $CONAN_BASE_PROFILE

--- a/android-clang_8-x86/Dockerfile
+++ b/android-clang_8-x86/Dockerfile
@@ -17,7 +17,7 @@ ENV ANDROID_ABI=x86 \
     OBJDUMP=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-objdump \
     READELF=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-readelf
 
-RUN conan profile update settings.arch=x86 default \
-    && conan profile update settings.os=Android default \
-    && conan profile update settings.os.api_level=16 default \
-    && conan profile update settings.compiler.libcxx=libc++ default
+RUN conan profile update settings.arch=x86 $CONAN_BASE_PROFILE \
+    && conan profile update settings.os=Android $CONAN_BASE_PROFILE \
+    && conan profile update settings.os.api_level=16 $CONAN_BASE_PROFILE \
+    && conan profile update settings.compiler.libcxx=libc++ $CONAN_BASE_PROFILE

--- a/android-clang_8/Dockerfile
+++ b/android-clang_8/Dockerfile
@@ -32,7 +32,8 @@ ENV ANDROID_NDK=$ANDROID_NDK \
     CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
     CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
     CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
-    PATH=$PATH:$STANDALONE_TOOLCHAIN/bin
+    PATH=$PATH:$STANDALONE_TOOLCHAIN/bin \
+    CONAN_BASE_PROFILE=android
 
 COPY cmake-wrapper /cmake-wrapper
 
@@ -43,7 +44,7 @@ RUN sudo apt-get update \
     && sudo unzip -qq android-ndk-r19c-linux-x86_64.zip -d / \
     && sudo rm -f android-ndk-r19c-linux-x86_64.zip \
     && sudo chmod +x /cmake-wrapper \
-    && conan profile new default --detect \
-    && conan profile update settings.os=Android default \
-    && conan profile update settings.os.api_level=21 default \
-    && conan profile update settings.compiler.libcxx=libc++ default
+    && conan profile new $CONAN_BASE_PROFILE --detect \
+    && conan profile update settings.os=Android $CONAN_BASE_PROFILE \
+    && conan profile update settings.os.api_level=21 $CONAN_BASE_PROFILE \
+    && conan profile update settings.compiler.libcxx=libc++ $CONAN_BASE_PROFILE


### PR DESCRIPTION
The default profile is always overwritten by conan package tools, 
so settings are now set in a custom profile: android

fixes #126

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [X] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
