### PR TITLE
One CI job, many docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,5 +310,4 @@ Upload related variables:
 - **DOCKER_PASSWORD**: Your Docker password to authenticate in Docker server
 - **DOCKER_UPLOAD**: If attributed to true, it will upload the generated docker image, positive words are accepted, e.g "True", "1", "Yes". Default "False"
 - **BUILD_CONAN_SERVER_IMAGE**: If attributest to true, it will build and upload an image with the conan_server
-- **BUILD_BASE_DISTRO**: Build base Docker image before building distro image. By default is True.
 - **DOCKER_UPLOAD_ONLY_WHEN_STABLE**: Only upload only when is master branch.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,257 +15,129 @@ jobs:
       DOCKER_PASSWORD: $(DOCKER_PASSWORD)
   strategy:
     matrix:
-      Jenkins Slave GCC 4.6 x86_64:
-        GCC_VERSIONS: "4.6"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 4.8 x86_64:
-        GCC_VERSIONS: "4.8"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 4.8 x86:
-        GCC_VERSIONS: "4.8"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 4.9 x86_64:
-        GCC_VERSIONS: "4.9"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 4.9 x86:
-        GCC_VERSIONS: "4.9"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 5 x86_64:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 5 x86:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 6 x86_64:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 6 x86:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 7 x86_64:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 7 x86:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 8 x86_64:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave GCC 8 x86:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Slave CentOS 6 GCC 7 x86_64:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave-centos6"
-      Jenkins Slave CentOS 6 GCC 7 x86:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave-centos6"
-      Jenkins Clang 3.9 x86_64:
-        CLANG_VERSIONS: "3.9"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 3.9 x86:
-        CLANG_VERSIONS: "3.9"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 4.0 x86_64:
-        CLANG_VERSIONS: "4.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 4.0 x86:
-        CLANG_VERSIONS: "4.0"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 5.0 x86_64:
-        CLANG_VERSIONS: "5.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 5.0 x86:
-        CLANG_VERSIONS: "5.0"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 6.0 x86_64:
-        CLANG_VERSIONS: "6.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 6.0 x86:
-        CLANG_VERSIONS: "6.0"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 7 x86_64:
-        CLANG_VERSIONS: "7"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 7 x86:
-        CLANG_VERSIONS: "7"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 8 x86_64:
-        CLANG_VERSIONS: "8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Jenkins Clang 8 x86:
-        CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
-
       CentOS 6 GCC 7 x86_64:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "centos6"
+        DOCKER_DISTRO: "centos6,jnlp-slave-centos6"
       CentOS 6 GCC 7 x86:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "centos6"
+        DOCKER_DISTRO: "centos6,jnlp-slave-centos6"
       Ubuntu MinGW GCC 7 x86_64:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64"
         DOCKER_DISTRO: "mingw"
 
-      Ubuntu GCC 4.6 x86_64:
+      Ubuntu GCC 4.6:
         GCC_VERSIONS: "4.6"
-      Ubuntu GCC 4.8 x86_64:
+        DOCKER_DISTRO: "jnlp-slave"
+      Ubuntu GCC 4.8:
         GCC_VERSIONS: "4.8"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 4.8 x86:
         GCC_VERSIONS: "4.8"
         DOCKER_ARCHS: "x86"
-      Ubuntu GCC 4.9 x86_64:
+        DOCKER_DISTRO: "jnlp-slave"
+      Ubuntu GCC 4.9:
         GCC_VERSIONS: "4.9"
+        DOCKER_ARCHS: "x86_64,armv7,armv7hf"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 4.9 x86:
         GCC_VERSIONS: "4.9"
         DOCKER_ARCHS: "x86"
-      Ubuntu GCC 5 x86_64:
+        DOCKER_DISTRO: "jnlp-slave"
+      Ubuntu GCC 5:
         GCC_VERSIONS: "5"
+        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 5 x86:
         GCC_VERSIONS: "5"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 5.2 x86_64:
         GCC_VERSIONS: "5.2"
       Ubuntu GCC 5.3 x86_64:
         GCC_VERSIONS: "5.3"
-      Ubuntu GCC 6 x86_64:
+      Ubuntu GCC 6:
         GCC_VERSIONS: "6"
+        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 6 x86:
         GCC_VERSIONS: "6"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 6.3 x86_64:
         GCC_VERSIONS: "6.3"
       Ubuntu GCC 6.4 x86_64:
         GCC_VERSIONS: "6.4"
-      Ubuntu GCC 7 x86_64:
+      Ubuntu GCC 7:
         GCC_VERSIONS: "7"
+        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 7 x86:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 7.2 x86_64:
         GCC_VERSIONS: "7.2"
-      Ubuntu GCC 8 x86_64:
+      Ubuntu GCC 8:
         GCC_VERSIONS: "8"
+        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 8 x86:
         GCC_VERSIONS: "8"
         DOCKER_ARCHS: "x86"
-
-      Ubuntu GCC 4.9 armv7:
-        GCC_VERSIONS: "4.9"
-        DOCKER_ARCHS: "x86_64,armv7"
-      Ubuntu GCC 4.9 armv7hf:
-        GCC_VERSIONS: "4.9"
-        DOCKER_ARCHS: "x86_64,armv7hf"
-      Ubuntu GCC 5 armv7:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86_64,armv7"
-      Ubuntu GCC 5 armv7hf:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86_64,armv7hf"
-      Ubuntu GCC 5 armv8:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86_64,armv8"
-      Ubuntu GCC 6 armv7:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86_64,armv7"
-      Ubuntu GCC 6 armv7hf:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86_64,armv7hf"
-      Ubuntu GCC 6 armv8:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86_64,armv8"
-      Ubuntu GCC 7 armv7:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64,armv7"
-      Ubuntu GCC 7 armv7hf:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64,armv7hf"
-      Ubuntu GCC 7 armv8:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64,armv8"
-      Ubuntu GCC 8 armv7:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64,armv7"
-      Ubuntu GCC 8 armv7hf:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64,armv7hf"
-      Ubuntu GCC 8 armv8:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64,armv8"
+        DOCKER_DISTRO: "jnlp-slave"
 
       Ubuntu Clang 3.8 x86_64:
         CLANG_VERSIONS: "3.8"
       Ubuntu Clang 3.9 x86_64:
         CLANG_VERSIONS: "3.9"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 3.9 x86:
         CLANG_VERSIONS: "3.9"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 4.0 x86_64:
         CLANG_VERSIONS: "4.0"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 4.0 x86:
         CLANG_VERSIONS: "4.0"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 5.0 x86_64:
         CLANG_VERSIONS: "5.0"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 5.0 x86:
         CLANG_VERSIONS: "5.0"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 6.0 x86_64:
         CLANG_VERSIONS: "6.0"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 6.0 x86:
         CLANG_VERSIONS: "6.0"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 7 x86_64:
         CLANG_VERSIONS: "7"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 7 x86:
         CLANG_VERSIONS: "7"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 8 x86_64:
         CLANG_VERSIONS: "8"
+        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 8 x86:
         CLANG_VERSIONS: "8"
         DOCKER_ARCHS: "x86"
+        DOCKER_DISTRO: "jnlp-slave"
 
-      Android Clang 8 x86:
+      Android Clang 8:
         DOCKER_CROSS: "android"
         CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "x86"
-      Android Clang 8 x86_64:
-        DOCKER_CROSS: "android"
-        CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64"
-      Android Clang 8 armv7:
-        DOCKER_CROSS: "android"
-        CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "armv7"
-      Android Clang 8 armv8:
-        DOCKER_CROSS: "android"
-        CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "armv8"
+        DOCKER_ARCHS: "x86_64,x86,armv7,armv8"
 
       Conan Server:
         BUILD_CONAN_SERVER_IMAGE: 1

--- a/build.py
+++ b/build.py
@@ -382,7 +382,7 @@ class ConanDockerTools(object):
                         self.linter(build_dir)
                         self.build()
                         self.tag()
-                        self.test("", compiler.name, version, distro)
+                        self.test("x86_64", compiler.name, version, distro)
                         self.info()
                         self.deploy()
 

--- a/build.py
+++ b/build.py
@@ -365,7 +365,7 @@ class ConanDockerTools(object):
                 for version in compiler.versions:
                     tag_arch = "" if arch == "x86_64" else "-%s" % arch
                     service = "%s%s%s%s" % (cross, compiler.name, version.replace(".", ""), tag_arch)
-                    build_dir = "%s_%s%s" % (cross, compiler.name, version, tag_arch)
+                    build_dir = "%s%s_%s%s" % (cross, compiler.name, version, tag_arch)
 
                     self.service = service
                     self.login()

--- a/build.py
+++ b/build.py
@@ -382,8 +382,8 @@ class ConanDockerTools(object):
                 for version in compiler.versions:
                     for distro in self.variables.docker_distro:
                         distro = "-%s" % distro
-                        service = "%s%s%s%s%s" % (cross, compiler.name, version.replace(".", ""), distro)
-                        build_dir = "%s%s_%s%s" % (cross, compiler.name, version, distro)
+                        service = "%s%s%s%s" % (compiler.name, version.replace(".", ""), distro)
+                        build_dir = "%s_%s%s" % (compiler.name, version, distro)
 
                         self.service = service
                         self.login()

--- a/build.py
+++ b/build.py
@@ -173,7 +173,7 @@ class ConanDockerTools(object):
         subprocess.call(
             'docker run --rm -i hadolint/hadolint < %s/Dockerfile' % build_dir, shell=True)
 
-    def test(self, arch, compiler_name, compiler_version, distro):
+    def test(self, arch, compiler_name, compiler_version, distro=""):
         """Validate Docker image by Conan install
         :param arch: Name of he architecture
         :param compiler_name: Compiler to be specified as conan setting e.g. clang

--- a/build.py
+++ b/build.py
@@ -390,7 +390,7 @@ class ConanDockerTools(object):
                         self.linter(build_dir)
                         self.build()
                         self.tag()
-                        self.test(arch, compiler.name, version, distro)
+                        self.test("", compiler.name, version, distro)
                         self.info()
                         self.deploy()
 

--- a/build.py
+++ b/build.py
@@ -48,7 +48,6 @@ class ConanDockerTools(object):
         docker_upload = self._get_boolean_var("DOCKER_UPLOAD")
         docker_upload_only_when_stable = self._get_boolean_var("DOCKER_UPLOAD_ONLY_WHEN_STABLE", "true")
         build_server = self._get_boolean_var("BUILD_CONAN_SERVER_IMAGE")
-        build_base_distro = self._get_boolean_var("BUILD_BASE_DISTRO", default="true")
         docker_password = os.getenv("DOCKER_PASSWORD", "").replace('"', '\\"')
         docker_username = os.getenv("DOCKER_USERNAME", "conanio")
         docker_login_username = os.getenv("DOCKER_LOGIN_USERNAME", "lasote")
@@ -75,12 +74,11 @@ class ConanDockerTools(object):
             "gcc_versions, docker_distro, "
             "clang_versions, visual_versions, build_server, "
             "docker_build_tag, docker_archs, sudo_command, "
-            "docker_upload_only_when_stable, docker_cross, docker_cache, "
-            "build_base_distro")
+            "docker_upload_only_when_stable, docker_cross, docker_cache")
         return Variables(docker_upload, docker_password, docker_username, docker_login_username,
                          gcc_versions, docker_distro, clang_versions, visual_versions, build_server,
                          docker_build_tag, docker_archs, sudo_command, docker_upload_only_when_stable,
-                         docker_cross, docker_cache, build_base_distro)
+                         docker_cross, docker_cache)
 
     def _get_boolean_var(self, var, default="false"):
         """ Parse environment variable as boolean type
@@ -145,14 +143,8 @@ class ConanDockerTools(object):
         :param service: service in compose e.g gcc54
         :param context: image dir
         """
-        no_cache = "" if self.variables.docker_cache else "--no-cache"
-
-        if self.variables.docker_distro and self.variables.build_base_distro:
-            base_service = self.service.replace("-%s" % self.variables.docker_distro, "")
-            logging.info("Starting build for base service %s." % base_service)
-            subprocess.check_call("docker-compose build %s %s" % (no_cache, base_service), shell=True)
-
         logging.info("Starting build for service %s." % self.service)
+        no_cache = "" if self.variables.docker_cache else "--no-cache"
         subprocess.check_call("docker-compose build %s %s" % (no_cache, self.service), shell=True)
 
         output = subprocess.check_output("docker image inspect %s --format '{{.Size}}'"

--- a/build.py
+++ b/build.py
@@ -364,7 +364,7 @@ class ConanDockerTools(object):
             for compiler in [self.gcc_compiler, self.clang_compiler, self.visual_compiler]:
                 for version in compiler.versions:
                     tag_arch = "" if arch == "x86_64" else "-%s" % arch
-                    service = "%s%s%s" % (cross, compiler.name, version.replace(".", ""), tag_arch)
+                    service = "%s%s%s%s" % (cross, compiler.name, version.replace(".", ""), tag_arch)
                     build_dir = "%s_%s%s" % (cross, compiler.name, version, tag_arch)
 
                     self.service = service

--- a/build.py
+++ b/build.py
@@ -382,7 +382,7 @@ class ConanDockerTools(object):
                 for version in compiler.versions:
                     for distro in self.variables.docker_distro:
                         distro = "-%s" % distro
-                        service = "%s%s%s%s" % (compiler.name, version.replace(".", ""), distro)
+                        service = "%s%s%s" % (compiler.name, version.replace(".", ""), distro)
                         build_dir = "%s_%s%s" % (compiler.name, version, distro)
 
                         self.service = service


### PR DESCRIPTION
Hi!

Since we are having trouble with CDT to re-use basic images (e.g. conanio/gcc8), this PR tries to unify many CI jobs as possible.

Before this PR I tried 2 other alternatives, but without sucess:
- Using Azure stages to build first all base images, and a second stage to build specialized images. It didn't work because it's not possible retrieving a docker image from previous stage. The experiment can be verified [here](https://github.com/uilianries/conan-docker-tools/blob/feature/multiple-stage/azure-pipelines.yml).
- Docker [multistage build](https://docs.docker.com/develop/develop-images/multistage-build/) is an incredible feature, so why not creating an unique Docker recipe with many different images? So I've created a docker [recipe](https://gist.github.com/uilianries/d691e55065791ca3e87172195fe2243f) for GCC8, including x86_64, armv7, armv7hf and armv8. However is not possible skipping a specific target when building ... I found [build_kit](https://docs.docker.com/develop/develop-images/build_enhancements/) which offers some flexibility, but it's not supported by docker-compose.

So this PR basically build all those images as before, but now all specialized images are on same CI job and following a specific order. For example, to build GCC8, first we build x86_64, armv7 and so on. Thus we don't need to re-build same x86_64 as before. The same idea is applied for distros, where we only need x86_64 to build Jenkins' images.

**PROS**:
- Less building time
- More re-usability of base images (x86_64)

**CONS**:
- Populated log containing many builds on same place.  

fixes #125 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
