### PR TITLE
Fix Clang 6

### DIFF
--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -15,31 +15,31 @@ COPY sources.list /etc/apt/sources.list
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.* \
-       wget=1.18* \
+       sudo=1.* \
+       wget=1.* \
        git=1:2.* \
-       clang-${LLVM_VERSION}=1:3.8.1-* \
-       llvm-${LLVM_VERSION}=1:3.8.1-* \
-       llvm-${LLVM_VERSION}-dev=1:3.8.1-* \
-       llvm-${LLVM_VERSION}-runtime=1:3.8.1-* \
-       llvm=1:4.0-* \
-       make=4.1-* \
-       libc6-dev-i386=2.24-* \
-       g++-multilib=4:6.3.* \
-       libgmp-dev=2:6.1.* \
-       libmpfr-dev=3.1.* \
-       libmpc-dev=1.0.* \
-       nasm=2.12.* \
+       clang-${LLVM_VERSION}=1:3.* \
+       llvm-${LLVM_VERSION}=1:3.* \
+       llvm-${LLVM_VERSION}-dev=1:3.* \
+       llvm-${LLVM_VERSION}-runtime=1:3.* \
+       llvm=1:4.* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       g++-multilib=4:6.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=13 \
-       libffi-dev=3.2.* \
-       libssl-dev=1.0.* \
-       ninja-build=1.7.* \
-       libc++-dev=3.9.* \
-       libc++-dev:i386=3.9.* \
-       libc++abi-dev=3.9.* \
-       libc++abi-dev:i386=3.9.* \
-       pkg-config=0.29.1-0ubuntu1 \
-       subversion=1.9.5-1ubuntu1.1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++-dev:i386=3.* \
+       libc++abi-dev=3.* \
+       libc++abi-dev:i386=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -56,14 +56,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -16,29 +16,29 @@ COPY sources.list /etc/apt/sources.list
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.20p2-1ubuntu1 \
-       wget=1.19.1-3ubuntu1 \
-       git=1:2.14.1-1ubuntu4 \
-       g++=4:7.2.0-1ubuntu1 \
-       clang-${LLVM_VERSION}=1:3.9.1-* \
-       llvm-${LLVM_VERSION}=1:3.9.1-* \
-       llvm-${LLVM_VERSION}-dev=1:3.9.1-* \
-       llvm-${LLVM_VERSION}-runtime=1:3.9.1-* \
-       llvm=1:4.0-* \
-       make=4.1-9.1 \
-       libc6-dev=2.26-0ubuntu2.1 \
-       libgmp-dev=2:6.1.2+dfsg-1 \
-       libmpfr-dev=3.1.6-1 \
-       libmpc-dev=1.0.3-2 \
-       nasm=2.13.01-2 \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++=4:7.* \
+       clang-${LLVM_VERSION}=1:3.* \
+       llvm-${LLVM_VERSION}=1:3.* \
+       llvm-${LLVM_VERSION}-dev=1:3.* \
+       llvm-${LLVM_VERSION}-runtime=1:3.* \
+       llvm=1:4.* \
+       make=4.* \
+       libc6-dev=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=14 \
-       libffi-dev=3.2.1-6 \
-       libssl-dev=1.0.2* \
-       ninja-build=1.7.2-3 \
-       libc++-dev=3.9.1-3 \
-       libc++abi-dev=3.9.1-3 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-2ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++abi-dev=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -57,9 +57,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -16,31 +16,31 @@ RUN dpkg --add-architecture i386 \
     && ls -lhR /etc/apt/ \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.20p2-1ubuntu1 \
-       wget=1.19.1-3ubuntu1 \
-       git=1:2.14.1-1ubuntu4 \
-       g++-multilib=4:7.2.0-1ubuntu1 \
-       clang-${LLVM_VERSION}=1:3.9.1-* \
-       llvm-${LLVM_VERSION}=1:3.9.1-* \
-       llvm-${LLVM_VERSION}-dev=1:3.9.1-* \
-       llvm-${LLVM_VERSION}-runtime=1:3.9.1-* \
-       llvm=1:4.0-* \
-       make=4.1-9.1 \
-       libc6-dev-i386=2.26-0ubuntu2.1 \
-       libgmp-dev=2:6.1.2+dfsg-1 \
-       libmpfr-dev=3.1.6-1 \
-       libmpc-dev=1.0.3-2 \
-       nasm=2.13.01-2 \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++-multilib=4:7.* \
+       clang-${LLVM_VERSION}=1:3.* \
+       llvm-${LLVM_VERSION}=1:3.* \
+       llvm-${LLVM_VERSION}-dev=1:3.* \
+       llvm-${LLVM_VERSION}-runtime=1:3.* \
+       llvm=1:4.* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=14 \
-       libffi-dev=3.2.1-6 \
-       libssl-dev=1.0.2* \
-       ninja-build=1.7.2-3 \
-       libc++-dev=3.9.1-3 \
-       libc++-dev:i386=3.9.1-3 \
-       libc++abi-dev=3.9.1-3 \
-       libc++abi-dev:i386=3.9.1-3 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-2ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++-dev:i386=3.* \
+       libc++abi-dev=3.* \
+       libc++abi-dev:i386=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -59,14 +59,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -16,29 +16,29 @@ COPY sources.list /etc/apt/sources.list
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.20p2-1ubuntu1 \
-       wget=1.19.1-3ubuntu1 \
-       git=1:2.14.1-1ubuntu4 \
-       g++=4:7.2.0-1ubuntu1 \
-       clang-${LLVM_VERSION}=1:4.0.1-6 \
-       llvm-${LLVM_VERSION}=1:4.0.1-6 \
-       llvm-${LLVM_VERSION}-dev=1:4.0.1-6 \
-       llvm-${LLVM_VERSION}-runtime=1:4.0.1-6 \
-       llvm=1:4.0-37~exp3ubuntu1 \
-       make=4.1-9.1 \
-       libc6-dev=2.26-0ubuntu2.1 \
-       libgmp-dev=2:6.1.2+dfsg-1 \
-       libmpfr-dev=3.1.6-1 \
-       libmpc-dev=1.0.3-2 \
-       nasm=2.13.01-2 \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++=4:7.* \
+       clang-${LLVM_VERSION}=1:4.* \
+       llvm-${LLVM_VERSION}=1:4.* \
+       llvm-${LLVM_VERSION}-dev=1:4.* \
+       llvm-${LLVM_VERSION}-runtime=1:4.* \
+       llvm=1:4.* \
+       make=4.* \
+       libc6-dev=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=14 \
-       libffi-dev=3.2.1-6 \
-       libssl-dev=1.0.2* \
-       ninja-build=1.7.2-3 \
-       libc++-dev=3.9.1-3 \
-       libc++abi-dev=3.9.1-3 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-2ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++abi-dev=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -57,9 +57,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -15,31 +15,31 @@ COPY sources.list /etc/apt/sources.list
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.20p2-1ubuntu1 \
-       wget=1.19.1-3ubuntu1 \
-       git=1:2.14.1-1ubuntu4 \
-       g++-multilib=4:7.2.0-1ubuntu1 \
-       clang-${LLVM_VERSION}=1:4.0.1-6 \
-       llvm-${LLVM_VERSION}=1:4.0.1-6 \
-       llvm-${LLVM_VERSION}-dev=1:4.0.1-6 \
-       llvm-${LLVM_VERSION}-runtime=1:4.0.1-6 \
-       llvm=1:4.0-37~exp3ubuntu1 \
-       make=4.1-9.1 \
-       libc6-dev-i386=2.26-0ubuntu2.1 \
-       libgmp-dev=2:6.1.2+dfsg-1 \
-       libmpfr-dev=3.1.6-1 \
-       libmpc-dev=1.0.3-2 \
-       nasm=2.13.01-2 \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++-multilib=4:7.* \
+       clang-${LLVM_VERSION}=1:4.* \
+       llvm-${LLVM_VERSION}=1:4.* \
+       llvm-${LLVM_VERSION}-dev=1:4.* \
+       llvm-${LLVM_VERSION}-runtime=1:4.* \
+       llvm=1:4.* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=14 \
-       libffi-dev=3.2.1-6 \
-       libssl-dev=1.0.2* \
-       ninja-build=1.7.2-3 \
-       libc++-dev=3.9.1-3 \
-       libc++-dev:i386=3.9.1-3 \
-       libc++abi-dev=3.9.1-3 \
-       libc++abi-dev:i386=3.9.1-3 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-2ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++-dev:i386=3.* \
+       libc++abi-dev=3.* \
+       libc++abi-dev:i386=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -58,14 +58,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -16,25 +16,25 @@ COPY sources.list /etc/apt/sources.list
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.20p2-1ubuntu1 \
-       wget=1.19.1-3ubuntu1 \
-       git=1:2.14.1-1ubuntu4 \
-       g++=4:7.2.0-1ubuntu1 \
-       clang-5.0=1:5.0-3 \
-       make=4.1-9.1 \
-       libc6-dev=2.26-0ubuntu2.1 \
-       libgmp-dev=2:6.1.2+dfsg-1 \
-       libmpfr-dev=3.1.6-1 \
-       libmpc-dev=1.0.3-2 \
-       nasm=2.13.01-2 \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++=4:7.* \
+       clang-5.0=1:5.* \
+       make=4.* \
+       libc6-dev=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=14 \
-       libffi-dev=3.2.1-6 \
-       libssl-dev=1.0.2* \
-       ninja-build=1.7.2-3 \
-       libc++-dev=3.9.1-3 \
-       libc++abi-dev=3.9.1-3 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-2ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++abi-dev=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -53,9 +53,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -15,27 +15,27 @@ COPY sources.list /etc/apt/sources.list
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.20p2-1ubuntu1 \
-       wget=1.19.1-3ubuntu1 \
-       git=1:2.14.1-1ubuntu4 \
-       g++-multilib=4:7.2.0-1ubuntu1 \
-       clang-5.0=1:5.0-3 \
-       make=4.1-9.1 \
-       libc6-dev-i386=2.26-0ubuntu2.1 \
-       libgmp-dev=2:6.1.2+dfsg-1 \
-       libmpfr-dev=3.1.6-1 \
-       libmpc-dev=1.0.3-2 \
-       nasm=2.13.01-2 \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++-multilib=4:7.* \
+       clang-5.0=1:5.* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=14 \
-       libffi-dev=3.2.1-6 \
-       libssl-dev=1.0.2* \
-       ninja-build=1.7.2-3 \
-       libc++-dev=3.9.1-3 \
-       libc++-dev:i386=3.9.1-3 \
-       libc++abi-dev=3.9.1-3 \
-       libc++abi-dev:i386=3.9.1-3 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-2ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=3.* \
+       libc++-dev:i386=3.* \
+       libc++abi-dev=3.* \
+       libc++abi-dev:i386=3.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -54,14 +54,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -14,25 +14,25 @@ ENV LLVM_VERSION=6.0 \
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.21p2-3ubuntu1 \
-       wget=1.19.4-1ubuntu2 \
+       sudo=1.* \
+       wget=1.* \
        git \
-       g++-multilib=4:7.3.0-3ubuntu2 \
-       clang-6.0=1:6.0-1ubuntu2 \
-       make=4.1-9.1ubuntu1 \
-       libc6-dev=2.27-3ubuntu1 \
-       libgmp-dev=2:6.1.2+dfsg-2 \
-       libmpfr-dev=4.0.1-1 \
-       libmpc-dev=1.1.0-1 \
-       nasm=2.13.02-0.1 \
+       g++-multilib=4:7.* \
+       clang-6.0=1:6.* \
+       make=4.* \
+       libc6-dev=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=4.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=17 \
-       libffi-dev=3.2.1-8 \
-       libssl-dev=1.1.0* \
-       ninja-build=1.8.2-1 \
-       libc++-dev=6.0-2 \
-       libc++abi-dev=6.0-2 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-4ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=6.* \
+       libc++abi-dev=6.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -13,27 +13,27 @@ ENV LLVM_VERSION=6.0 \
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-       sudo=1.8.21p2-3ubuntu1 \
-       wget=1.19.4-1ubuntu2 \
+       sudo=1.* \
+       wget=1.* \
        git \
-       g++-multilib=4:7.3.0-3ubuntu2 \
-       clang-6.0=1:6.0-1ubuntu2 \
-       make=4.1-9.1ubuntu1 \
-       libc6-dev-i386=2.27-3ubuntu1 \
-       libgmp-dev=2:6.1.2+dfsg-2 \
-       libmpfr-dev=4.0.1-1 \
-       libmpc-dev=1.1.0-1 \
-       nasm=2.13.02-0.1 \
+       g++-multilib=4:7.* \
+       clang-6.0=1:6.* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=4.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=17 \
-       libffi-dev=3.2.1-8 \
-       libssl-dev=1.1.0* \
-       ninja-build=1.8.2-1 \
-       libc++-dev=6.0-2 \
-       libc++-dev:i386=6.0-2 \
-       libc++abi-dev=6.0-2 \
-       libc++abi-dev:i386=6.0-2 \
-       pkg-config=0.29.1-0ubuntu2 \
-       subversion=1.9.7-4ubuntu1 \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       ninja-build=1.* \
+       libc++-dev=6.* \
+       libc++-dev:i386=6.* \
+       libc++abi-dev=6.* \
+       libc++abi-dev:i386=6.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -52,14 +52,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -14,25 +14,25 @@ ENV LLVM_VERSION=7.0 \
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.8.* \
-       wget=1.19.* \
-       git=1:2.19.* \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
        g++-multilib=4:8.* \
-       clang-7=1:7-* \
-       make=4.2.* \
+       clang-7=1:* \
+       make=4.* \
        libc6-dev=2.* \
-       libgmp-dev=2:6.1.* \
-       libmpfr-dev=4.0.* \
-       libmpc-dev=1.1.* \
-       nasm=2.13.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=4.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=19 \
-       libffi-dev=3.2.* \
+       libffi-dev=3.* \
        libssl-dev=1.* \
-       ninja-build=1.8.* \
-       libc++-dev=6.0.* \
-       libc++abi-dev=6.0.* \
-       pkg-config=0.29.* \
-       subversion=1.10.* \
+       ninja-build=1.* \
+       libc++-dev=6.* \
+       libc++abi-dev=6.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -13,27 +13,27 @@ ENV LLVM_VERSION=7.0 \
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-       sudo=1.8.* \
-       wget=1.19.* \
-       git=1:2.19.* \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
        g++-multilib=4:8.* \
-       clang-7=1:7-* \
-       make=4.2.* \
+       clang-7=1:* \
+       make=4.* \
        libc6-dev-i386=2.* \
-       libgmp-dev=2:6.1.* \
-       libmpfr-dev=4.0.* \
-       libmpc-dev=1.1.* \
-       nasm=2.13* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=4.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
        dh-autoreconf=19 \
-       libffi-dev=3.2.* \
+       libffi-dev=3.* \
        libssl-dev=1* \
-       ninja-build=1.8.* \
-       libc++-dev=6.0.* \
-       libc++-dev:i386=6.0.* \
-       libc++abi-dev=6.0.* \
-       libc++abi-dev:i386=6.0.* \
-       pkg-config=0.29.* \
-       subversion=1.10.* \
+       ninja-build=1.* \
+       libc++-dev=6.* \
+       libc++-dev:i386=6.* \
+       libc++abi-dev=6.* \
+       libc++abi-dev:i386=6.* \
+       pkg-config=0.* \
+       subversion=1.* \
        zlib1g-dev=1:1.* \
        libbz2-dev=1.* \
        libsqlite3-dev=3.* \
@@ -52,14 +52,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.12/cmake-3.12.1.tar.gz \
-    && tar -xzf cmake-3.12.1.tar.gz \
-    && cd cmake-3.12.1 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -55,14 +55,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.12.1-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.12.1-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.12.1-Linux-x86_64 \
-    && rm cmake-3.12.1-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -41,14 +41,14 @@ RUN dpkg --add-architecture i386 \
        golang \
        pkg-config \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.14.3-Linux-x86_64 \
-       && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.14.5-Linux-x86_64 \
+       && rm cmake-3.14.5-Linux-x86_64.tar.gz \
        && wget -q --no-check-certificate https://bootstrap.pypa.io/get-pip.py \
        && python3 get-pip.py \
        && rm get-pip.py \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -34,13 +34,13 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /tmp/cmake-3.14.3-Linux-x86_64.tar.gz http://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf /tmp/cmake-3.14.3-Linux-x86_64.tar.gz -C /tmp \
+    && wget -q --no-check-certificate -O /tmp/cmake-3.14.5-Linux-x86_64.tar.gz http://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf /tmp/cmake-3.14.5-Linux-x86_64.tar.gz -C /tmp \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR /tmp/cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf /tmp/cmake-3.14.3-Linux-x86_64* \
+    && cp -fR /tmp/cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf /tmp/cmake-3.14.5-Linux-x86_64* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -36,9 +36,9 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -36,14 +36,14 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -34,14 +34,14 @@ RUN apt-get -qq update \
     autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -36,14 +36,14 @@ RUN dpkg --add-architecture armhf \
     autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -43,9 +43,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -43,14 +43,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -39,9 +39,9 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-       && tar -xzf cmake-3.14.3.tar.gz \
-       && cd cmake-3.14.3 \
+       && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+       && tar -xzf cmake-3.14.5.tar.gz \
+       && cd cmake-3.14.5 \
        && ./bootstrap > /dev/null \
        && make -s -j`nproc` \
        && make -s install > /dev/null \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -37,14 +37,14 @@ RUN dpkg --add-architecture i386 \
     ca-certificates \
     autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -85,14 +85,14 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && ln -s /usr/bin/g++-5 /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.14/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -39,14 +39,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.14.3-Linux-x86_64 \
-       && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.14.5-Linux-x86_64 \
+       && rm cmake-3.14.5-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -39,14 +39,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
           --exclude=bin/cmake-gui \
           --exclude=doc/cmake \
           --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.14.3-Linux-x86_64 \
-       && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.14.5-Linux-x86_64 \
+       && rm cmake-3.14.5-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -41,14 +41,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -41,14 +41,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -46,14 +46,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -47,14 +47,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -67,9 +67,9 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-    && wget --no-check-certificate --quiet -O /tmp/cmake-3.14.3.tar.gz https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf /tmp/cmake-3.14.3.tar.gz -C /tmp \
-    && pushd /tmp/cmake-3.14.3 \
+    && wget --no-check-certificate --quiet -O /tmp/cmake-3.14.5.tar.gz https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf /tmp/cmake-3.14.5.tar.gz -C /tmp \
+    && pushd /tmp/cmake-3.14.5 \
     && ./bootstrap \
     && make -s -j`nproc` > /dev/null \
     && make -s install > /dev/null \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -59,9 +59,9 @@ RUN yum update -y \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-    && wget -O /tmp/cmake-3.14.3-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.sh' \
-    && bash /tmp/cmake-3.14.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
-    && rm /tmp/cmake-3.14.3-Linux-x86_64.sh \
+    && wget -O /tmp/cmake-3.14.5-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh' \
+    && bash /tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
+    && rm /tmp/cmake-3.14.5-Linux-x86_64.sh \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -44,14 +44,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -45,14 +45,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -45,14 +45,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3.tar.gz \
-    && tar -xzf cmake-3.14.3.tar.gz \
-    && cd cmake-3.14.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz \
+    && tar -xzf cmake-3.14.5.tar.gz \
+    && cd cmake-3.14.5 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -45,14 +45,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.14.5-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.14.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.14.3-Linux-x86_64 \
-    && rm cmake-3.14.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.14.5-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.14.5-Linux-x86_64 \
+    && rm cmake-3.14.5-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/update_cmake.py
+++ b/update_cmake.py
@@ -4,7 +4,7 @@ import os
 
 if __name__ == "__main__":
 
-    for old, new in [("3.14.2", "3.14.3"), ("v3.14ca", "v3.14")]:
+    for old, new in [("3.14.3", "3.14.5"), ("v3.14", "v3.14")]:
 
         for root, _, filenames in os.walk("./"):
             for filename in filenames:


### PR DESCRIPTION
- Install major package version only
- Update CMake version

Changelog: Fix: Clang images only install packages with major version

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
