### PR TITLE
#141 Build newest Git version

### DIFF
--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -55,7 +55,7 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
     && pushd /tmp/git-2.22.0 \
     && ./configure --prefix=/usr --without-tcltk --with-curl \
-    && make \
+    && make -s \
     && make install \
     && yum remove -y gettext libcurl-devel \
     && popd \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -21,7 +21,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && yum install -y \
        sudo \
        wget \
-       git \
        make \
        glibc-devel \
        gmp-devel \
@@ -49,7 +48,18 @@ RUN printf "i686" >  /etc/yum/vars/arch \
        perl-core \
        help2man \
        autoconf-archive \
+       gettext \
+       libcurl-devel \
     && yum clean all \
+    && wget -O /tmp/git-2.22.0.tar.gz --no-check-certificate --quiet https://www.kernel.org/pub/software/scm/git/git-2.22.0.tar.gz \
+    && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
+    && pushd /tmp/git-2.22.0 \
+    && ./configure --prefix=/usr --without-tcltk --with-curl \
+    && make \
+    && make install \
+    && yum remove -y gettext libcurl-devel \
+    && popd \
+    && rm -rf /tmp/git-* \
     && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
     && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
     && pushd /tmp/autoconf-2.69 \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -47,7 +47,7 @@ RUN yum update -y \
     && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
     && pushd /tmp/git-2.22.0 \
     && ./configure --prefix=/usr --without-tcltk --with-curl \
-    && make \
+    && make -s \
     && make install \
     && yum remove -y gettext libcurl-devel \
     && popd \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -18,7 +18,6 @@ RUN yum update -y \
     && yum install -y \
        sudo \
        wget \
-       git \
        make \
        glibc-devel \
        glibc-devel.i686 \
@@ -41,7 +40,18 @@ RUN yum update -y \
        rh-python36 \
        help2man \
        autoconf-archive \
+       gettext \
+       libcurl-devel \
     && yum clean all \
+    && wget -O /tmp/git-2.22.0.tar.gz --no-check-certificate --quiet https://www.kernel.org/pub/software/scm/git/git-2.22.0.tar.gz \
+    && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
+    && pushd /tmp/git-2.22.0 \
+    && ./configure --prefix=/usr --without-tcltk --with-curl \
+    && make \
+    && make install \
+    && yum remove -y gettext libcurl-devel \
+    && popd \
+    && rm -rf /tmp/git-* \
     && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
     && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
     && pushd /tmp/autoconf-2.69 \


### PR DESCRIPTION
- Build newest stable Git version for CentOS6

Changelog: Feature: Install Git 2.20.0 for CentOS6

closes https://github.com/conan-io/conan-docker-tools/issues/141

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
