### PR TITLE
set CONAN_CLANG/GCC_VERSIONS env var

### DIFF
--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -11,6 +11,8 @@ ENV LLVM_VERSION=9.0 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
+	
+COPY sources.list /etc/apt/sources.list
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/clang_9-x86/sources.list
+++ b/clang_9-x86/sources.list
@@ -1,0 +1,17 @@
+deb http://old-releases.ubuntu.com/ubuntu/ eoan main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates main restricted
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security multiverse 

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -9,6 +9,8 @@ ENV LLVM_VERSION=9.0 \
     CMAKE_CXX_COMPILER=clang++ \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
+	
+COPY sources.list /etc/apt/sources.list
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \

--- a/clang_9/sources.list
+++ b/clang_9/sources.list
@@ -1,0 +1,17 @@
+deb http://old-releases.ubuntu.com/ubuntu/ eoan main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates main restricted
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security multiverse 

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -8,6 +8,8 @@ ENV CONAN_ENV_ARCH=x86 \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
     CC=/usr/bin/gcc
+	
+COPY sources.list /etc/apt/sources.list
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/gcc_9-x86/sources.list
+++ b/gcc_9-x86/sources.list
@@ -1,0 +1,17 @@
+deb http://old-releases.ubuntu.com/ubuntu/ eoan main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates main restricted
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security multiverse 

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -6,6 +6,8 @@ ENV PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
     CC=/usr/bin/gcc
+	
+COPY sources.list /etc/apt/sources.list
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \

--- a/gcc_9/sources.list
+++ b/gcc_9/sources.list
@@ -1,0 +1,17 @@
+deb http://old-releases.ubuntu.com/ubuntu/ eoan main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates main restricted
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-updates universe
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb-src http://old-releases.ubuntu.com/ubuntu/ eoan-security universe
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security multiverse 


### PR DESCRIPTION
This simplifies the use of conan package tools in CI: with this change one can set a matrix job setting only the docker image to use, and CPT automatically picks up the proper GCC or clang version, based on the environment variables set by the image