### PR TITLE
Create alias for clang 7

### DIFF
--- a/build.py
+++ b/build.py
@@ -319,12 +319,24 @@ class ConanDockerTools(object):
         logging.info("Upload Docker image %s" % self.tagged_image_name)
         subprocess.check_call("docker push %s" % self.tagged_image_name, shell=True)
 
+        if self.service == "clang7":
+            logging.info("Clang 7 will upload the alias Clang 7.0")
+            subprocess.check_call("docker push %s" %
+                self.tagged_image_name.replace("clang7", "clang70"), shell=True)
+
     def tag(self):
         """Apply Docker tag name
         """
         logging.info("Creating Docker tag %s" % self.tagged_image_name)
         subprocess.check_call("docker tag %s %s" % (self.created_image_name,
             self.tagged_image_name), shell=True)
+
+        # clang7 is represented by clang7.0 in Conan settings
+        if self.service == "clang7":
+            logging.info("Clang 7 will produce the alias Clang 7.0")
+            subprocess.check_call("docker tag %s %s" % (self.created_image_name,
+            self.tagged_image_name.replace("clang7", "clang70")), shell=True)
+
 
     def info(self):
         """Show Docker image info


### PR DESCRIPTION
Since Clang 7 is available as clang 7.0 in Conan settings and LLVM just released Clang 7.1, I think this alias can help to build with CPT:

    CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=clang70

Original discussion: https://cpplang.slack.com/archives/C41CWV9HA/p1568472642006400

/cc @Minimonium @ericLemanissier 

Changelog: Feature: Create alias for clang7 as clang70

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
