### PR TITLE
Fix clang70 tag

### DIFF
--- a/build.py
+++ b/build.py
@@ -336,7 +336,8 @@ class ConanDockerTools(object):
             logging.info("Clang 7 will produce the alias Clang 7.0")
             subprocess.check_call("docker tag %s %s" % (self.created_image_name,
             self.tagged_image_name.replace("clang7", "clang70")), shell=True)
-
+            subprocess.check_call("docker tag %s/clang7 %s/clang70" %
+            (self.variables.docker_username, self.variables.docker_username), shell=True)
 
     def info(self):
         """Show Docker image info


### PR DESCRIPTION
Part of log after building with this patch:

```
2019-10-24 09:29:50,395 [INFO]: Show Docker image conanio/clang7:latest size:
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
conanio/clang7      latest              fcdc6a30c8a1        2 minutes ago       858MB
2019-10-24 09:29:50,667 [INFO]: Show Docker image conanio/clang7:latest info:
[
    {
        "Id": "sha256:fcdc6a30c8a17a56609c708a44b63e509156137ec0c3ab2e6533aaa1b9543982",
        "RepoTags": [
            "conanio/clang70:1.19.2",
            "conanio/clang70:latest",
            "conanio/clang7:1.19.2",
            "conanio/clang7:latest"
        ],
        "RepoDigests": [],
        "Parent": "sha256:56784d6034226c3774cb076384673dcea2646f2f2767783d923b5a340f31add8",
        "Comment": "",
```

As you can see, both versions (latest and 1.19.2) have an individual tag.

Changelog: Fix: Add tag for clang70 latest
/cc @ericLemanissier @Croydon 
related PR: #147 

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
