### PR TITLE
Update GCC9

### DIFF
--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -77,8 +77,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -56,14 +56,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -57,9 +57,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -78,8 +78,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -80,8 +80,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -59,14 +59,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -57,9 +57,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -78,8 +78,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -79,8 +79,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -58,14 +58,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -53,9 +53,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -74,8 +74,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -75,8 +75,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -54,14 +54,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -52,14 +52,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -73,8 +73,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -52,14 +52,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -73,8 +73,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -76,8 +76,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -55,14 +55,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -51,9 +51,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -73,8 +73,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -52,14 +52,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -41,14 +41,14 @@ RUN dpkg --add-architecture i386 \
        golang \
        pkg-config \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.15.3-Linux-x86_64 \
-       && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.16.1-Linux-x86_64 \
+       && rm cmake-3.16.1-Linux-x86_64.tar.gz \
        && wget -q --no-check-certificate https://bootstrap.pypa.io/get-pip.py \
        && python3 get-pip.py \
        && rm get-pip.py \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -34,13 +34,13 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /tmp/cmake-3.15.3-Linux-x86_64.tar.gz http://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf /tmp/cmake-3.15.3-Linux-x86_64.tar.gz -C /tmp \
+    && wget -q --no-check-certificate -O /tmp/cmake-3.16.1-Linux-x86_64.tar.gz http://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf /tmp/cmake-3.16.1-Linux-x86_64.tar.gz -C /tmp \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR /tmp/cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf /tmp/cmake-3.15.3-Linux-x86_64* \
+    && cp -fR /tmp/cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf /tmp/cmake-3.16.1-Linux-x86_64* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -36,9 +36,9 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -36,14 +36,14 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -34,14 +34,14 @@ RUN apt-get -qq update \
     autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -36,14 +36,14 @@ RUN dpkg --add-architecture armhf \
     autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -43,9 +43,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -43,14 +43,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -39,9 +39,9 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-       && tar -xzf cmake-3.15.3.tar.gz \
-       && cd cmake-3.15.3 \
+       && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+       && tar -xzf cmake-3.16.1.tar.gz \
+       && cd cmake-3.16.1 \
        && ./bootstrap > /dev/null \
        && make -s -j`nproc` \
        && make -s install > /dev/null \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -60,8 +60,8 @@ RUN apt-get -qq update \
        && /tmp/pyenv-installer \
        && rm /tmp/pyenv-installer \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-       && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-       && pyenv global 3.7.1 \
+       && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+       && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -58,8 +58,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -37,14 +37,14 @@ RUN dpkg --add-architecture i386 \
     ca-certificates \
     autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -85,14 +85,14 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && ln -s /usr/bin/g++-5 /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.14/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -106,8 +106,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && pip install -q --upgrade --no-cache-dir pip \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -60,8 +60,8 @@ RUN dpkg --add-architecture i386 \
        && /tmp/pyenv-installer \
        && rm /tmp/pyenv-installer \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-       && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-       && pyenv global 3.7.1 \
+       && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+       && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -39,14 +39,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.15.3-Linux-x86_64 \
-       && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.16.1-Linux-x86_64 \
+       && rm cmake-3.16.1-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -39,14 +39,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
           --exclude=bin/cmake-gui \
           --exclude=doc/cmake \
           --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.15.3-Linux-x86_64 \
-       && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.16.1-Linux-x86_64 \
+       && rm cmake-3.16.1-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -60,8 +60,8 @@ RUN dpkg --add-architecture i386 \
        && /tmp/pyenv-installer \
        && rm /tmp/pyenv-installer \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-       && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-       && pyenv global 3.7.1 \
+       && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+       && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -69,8 +69,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -41,14 +41,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -62,8 +62,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -41,14 +41,14 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -62,8 +62,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -67,8 +67,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -46,14 +46,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -47,14 +47,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -68,8 +68,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -77,9 +77,9 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-    && wget --no-check-certificate --quiet -O /tmp/cmake-3.15.3.tar.gz https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf /tmp/cmake-3.15.3.tar.gz -C /tmp \
-    && pushd /tmp/cmake-3.15.3 \
+    && wget --no-check-certificate --quiet -O /tmp/cmake-3.16.1.tar.gz https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf /tmp/cmake-3.16.1.tar.gz -C /tmp \
+    && pushd /tmp/cmake-3.16.1 \
     && ./bootstrap \
     && make -s -j`nproc` > /dev/null \
     && make -s install > /dev/null \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -77,6 +77,14 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
+    && wget --quiet -O /tmp/OpenSSL_1_0_2q.tar.gz https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz \
+    && tar zxf /tmp/OpenSSL_1_0_2q.tar.gz -C /tmp \
+    && pushd /tmp/openssl-OpenSSL_1_0_2q \
+    && ./Configure --prefix=/usr shared zlib linux-generic32 \
+    && make -j`nproc` > /dev/null \
+    && make install > /dev/null \
+    && popd \
+    && rm -rf /tmp/openssl-* /tmp/OpenSSL* \
     && wget --no-check-certificate --quiet -O /tmp/cmake-3.16.1.tar.gz https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
     && tar -xzf /tmp/cmake-3.16.1.tar.gz -C /tmp \
     && pushd /tmp/cmake-3.16.1 \
@@ -88,14 +96,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
-    && wget --quiet -O /tmp/OpenSSL_1_0_2q.tar.gz https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz \
-    && tar zxf /tmp/OpenSSL_1_0_2q.tar.gz -C /tmp \
-    && pushd /tmp/openssl-OpenSSL_1_0_2q \
-    && ./Configure --prefix=/usr shared zlib linux-generic32 \
-    && make -j`nproc` > /dev/null \
-    && make install > /dev/null \
-    && popd \
-    && rm -rf /tmp/openssl-* /tmp/OpenSSL* \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && pyenv install 3.6.7 \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -69,9 +69,9 @@ RUN yum update -y \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-    && wget -O /tmp/cmake-3.15.3-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh' \
-    && bash /tmp/cmake-3.15.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
-    && rm /tmp/cmake-3.15.3-Linux-x86_64.sh \
+    && wget -O /tmp/cmake-3.16.1-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.sh' \
+    && bash /tmp/cmake-3.16.1-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
+    && rm /tmp/cmake-3.16.1-Linux-x86_64.sh \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -69,8 +69,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -44,14 +44,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -65,8 +65,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -66,8 +66,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -45,14 +45,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -67,8 +67,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -45,14 +45,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -66,8 +66,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -67,8 +67,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:disco
+FROM i386/ubuntu:eoan
 ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf cmake-3.15.3.tar.gz \
-    && cd cmake-3.15.3 \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz \
+    && tar -xzf cmake-3.16.1.tar.gz \
+    && cd cmake-3.16.1 \
     && ./bootstrap > /dev/null \
     && make -s -j`nproc` \
     && make -s install > /dev/null \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:eoan
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -45,14 +45,14 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.1-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
        --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.16.1-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.1-Linux-x86_64 \
+    && rm cmake-3.16.1-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -66,8 +66,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.1 \
-    && pyenv global 3.7.1 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/update_cmake.py
+++ b/update_cmake.py
@@ -4,7 +4,7 @@ import os
 
 if __name__ == "__main__":
 
-    for old, new in [("3.15.3", "3.15.3"), ("v3.15", "v3.15")]:
+    for old, new in [("3.15.3", "3.16.1"), ("v3.15", "v3.16")]:
 
         for root, _, filenames in os.walk("./"):
             for filename in filenames:


### PR DESCRIPTION
- Update Docker image GCC9 to use Ubuntu oean instead (GCC 9.2 by default)
- Update CMake version to 3.16.1 (latest)
- Update Python version to 3.7.5 (latest from 3.7)

Changelog: Feature: Update Docker image for GCC 9.2

closes #158 


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
