### PR TITLE
Install libtool

### DIFF
--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -52,6 +52,14 @@ RUN yum update -y \
     && yum remove -y gettext libcurl-devel \
     && popd \
     && rm -rf /tmp/git-* \
+    && wget -O /tmp/libtool-2.4.6.tar.gz --no-check-certificate --quiet  http://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.gz \
+    && tar -zxf /tmp/libtool-2.4.6.tar.gz -C /tmp \
+    && pushd /tmp/libtool-2.4.6 \
+    && ./configure --prefix=/usr \
+    && make -s \
+    && make install \
+    && popd \
+    && rm -rf /tmp/libtool-2.4.6* \
     && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
     && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
     && pushd /tmp/autoconf-2.69 \


### PR DESCRIPTION
Changelog: Feature : Add libtool to the gcc7-centos6 image

`libcurl` depends on `libtool` version > 1.4.2.  This PR adds the current stable version of `libtool` to the base image/

fixes #162 

- [x] Refer to the issue that supports this Pull Request.
- [NA] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [NA] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
