### PR TITLE
Use distribution version of autotools and libtools

### DIFF
--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -60,10 +60,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && yum remove -y gettext libcurl-devel \
     && popd \
     && rm -rf /tmp/git-* \
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Revert "Port addition of libtool and replacement of external autoconf and automake already verified on 64-bit version to the -x86 Dockerfile version. Sort the yum packages to make it easier to diff between Dockerfile versions and remove duplicate packages"
     && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
     && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
     && pushd /tmp/autoconf-2.69 \
@@ -81,22 +77,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Revert "Port addition of libtool and replacement of external autoconf and automake already verified on 64-bit version to the -x86 Dockerfile version. Sort the yum packages to make it easier to diff between Dockerfile versions and remove duplicate packages"
-    && wget --no-check-certificate --quiet -O /tmp/cmake-3.15.3.tar.gz https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
-    && tar -xzf /tmp/cmake-3.15.3.tar.gz -C /tmp \
-    && pushd /tmp/cmake-3.15.3 \
-    && ./bootstrap \
-    && make -s -j`nproc` > /dev/null \
-    && make -s install > /dev/null \
-    && popd \
-    && rm -rf /tmp/cmake-* \
-    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
-    && chmod +x /tmp/pyenv-installer \
-    && /tmp/pyenv-installer \
->>>>>>> Port addition of libtool and replacement of external autoconf and automake already verified on 64-bit version to the -x86 Dockerfile version. Sort the yum packages to make it easier to diff between Dockerfile versions and remove duplicate packages
     && wget --quiet -O /tmp/OpenSSL_1_0_2q.tar.gz https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz \
     && tar zxf /tmp/OpenSSL_1_0_2q.tar.gz -C /tmp \
     && pushd /tmp/openssl-OpenSSL_1_0_2q \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -19,30 +19,37 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && printf "i386" >  /etc/yum/vars/basearch \
     && yum update -y \
     && yum install -y \
-       autoconf \
-       autoconf-archive \
-       automake \
-       curl \
-       devtoolset-7-toolchain \
-       gettext \
-       glibc-devel \
-       help2man \
-       libcurl-devel \
-       libffi-devel \
-       libtool \
+       sudo \
+       wget \
        make \
+       glibc-devel \
+       gmp-devel \
+       mpfr-devel \
+       libmpc-devel \
        nasm \
-       perl-core \
+       m4 \
+       libffi-devel \
        pkgconfig \
+       subversion \
+       xz \
+       curl \
+       xz-devel \
+       tar \
+       devtoolset-7-toolchain \
+       zlib-devel \
+       bzip2 \
+       bzip2-devel \
+       readline-devel \
        sqlite \
        sqlite-devel \
-       subversion \
-       sudo \
-       tar \
-       wget \
-       xz \
-       zlib \
-       zlib-devel \
+       tk-devel \
+       libffi-devel \
+       libtool \
+       perl-core \
+       help2man \
+       autoconf-archive \
+       gettext \
+       libcurl-devel \
     && yum clean all \
     && wget -O /tmp/git-2.22.0.tar.gz --no-check-certificate --quiet https://www.kernel.org/pub/software/scm/git/git-2.22.0.tar.gz \
     && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
@@ -50,9 +57,13 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && ./configure --prefix=/usr --without-tcltk --with-curl \
     && make -s \
     && make install \
+    && yum remove -y gettext libcurl-devel \
     && popd \
     && rm -rf /tmp/git-* \
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Revert "Port addition of libtool and replacement of external autoconf and automake already verified on 64-bit version to the -x86 Dockerfile version. Sort the yum packages to make it easier to diff between Dockerfile versions and remove duplicate packages"
     && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
     && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
     && pushd /tmp/autoconf-2.69 \
@@ -70,7 +81,10 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> Revert "Port addition of libtool and replacement of external autoconf and automake already verified on 64-bit version to the -x86 Dockerfile version. Sort the yum packages to make it easier to diff between Dockerfile versions and remove duplicate packages"
     && wget --no-check-certificate --quiet -O /tmp/cmake-3.15.3.tar.gz https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
     && tar -xzf /tmp/cmake-3.15.3.tar.gz -C /tmp \
     && pushd /tmp/cmake-3.15.3 \
@@ -114,7 +128,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
-    && yum remove -y gettext zlib-devel libcurl-devel \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -19,37 +19,30 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && printf "i386" >  /etc/yum/vars/basearch \
     && yum update -y \
     && yum install -y \
-       sudo \
-       wget \
-       make \
-       glibc-devel \
-       gmp-devel \
-       mpfr-devel \
-       libmpc-devel \
-       nasm \
-       m4 \
-       libffi-devel \
-       pkgconfig \
-       subversion \
-       xz \
+       autoconf \
+       autoconf-archive \
+       automake \
        curl \
-       xz-devel \
-       tar \
        devtoolset-7-toolchain \
-       zlib-devel \
-       bzip2 \
-       bzip2-devel \
-       readline-devel \
-       sqlite \
-       sqlite-devel \
-       tk-devel \
+       gettext \
+       glibc-devel \
+       help2man \
+       libcurl-devel \
        libffi-devel \
        libtool \
+       make \
+       nasm \
        perl-core \
-       help2man \
-       autoconf-archive \
-       gettext \
-       libcurl-devel \
+       pkgconfig \
+       sqlite \
+       sqlite-devel \
+       subversion \
+       sudo \
+       tar \
+       wget \
+       xz \
+       zlib \
+       zlib-devel \
     && yum clean all \
     && wget -O /tmp/git-2.22.0.tar.gz --no-check-certificate --quiet https://www.kernel.org/pub/software/scm/git/git-2.22.0.tar.gz \
     && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
@@ -57,9 +50,9 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && ./configure --prefix=/usr --without-tcltk --with-curl \
     && make -s \
     && make install \
-    && yum remove -y gettext libcurl-devel \
     && popd \
     && rm -rf /tmp/git-* \
+<<<<<<< HEAD
     && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
     && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
     && pushd /tmp/autoconf-2.69 \
@@ -77,6 +70,19 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
+=======
+    && wget --no-check-certificate --quiet -O /tmp/cmake-3.15.3.tar.gz https://cmake.org/files/v3.15/cmake-3.15.3.tar.gz \
+    && tar -xzf /tmp/cmake-3.15.3.tar.gz -C /tmp \
+    && pushd /tmp/cmake-3.15.3 \
+    && ./bootstrap \
+    && make -s -j`nproc` > /dev/null \
+    && make -s install > /dev/null \
+    && popd \
+    && rm -rf /tmp/cmake-* \
+    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && chmod +x /tmp/pyenv-installer \
+    && /tmp/pyenv-installer \
+>>>>>>> Port addition of libtool and replacement of external autoconf and automake already verified on 64-bit version to the -x86 Dockerfile version. Sort the yum packages to make it easier to diff between Dockerfile versions and remove duplicate packages
     && wget --quiet -O /tmp/OpenSSL_1_0_2q.tar.gz https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz \
     && tar zxf /tmp/OpenSSL_1_0_2q.tar.gz -C /tmp \
     && pushd /tmp/openssl-OpenSSL_1_0_2q \
@@ -108,6 +114,7 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
+    && yum remove -y gettext zlib-devel libcurl-devel \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -22,11 +22,7 @@ RUN yum update -y \
        glibc-devel \
        glibc-devel.i686 \
        libgcc.i686 \
-       gmp-devel \
-       mpfr-devel \
-       libmpc-devel \
        nasm \
-       m4 \
        libffi-devel \
        openssl-devel \
        pkgconfig \
@@ -34,7 +30,6 @@ RUN yum update -y \
        zlib-devel \
        xz \
        curl \
-       xz-devel \
        tar \
        devtoolset-7-toolchain \
        rh-python36 \
@@ -42,6 +37,9 @@ RUN yum update -y \
        autoconf-archive \
        gettext \
        libcurl-devel \
+       autoconf \
+       automake \
+       libtools \
     && yum clean all \
     && wget -O /tmp/git-2.22.0.tar.gz --no-check-certificate --quiet https://www.kernel.org/pub/software/scm/git/git-2.22.0.tar.gz \
     && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \
@@ -49,26 +47,9 @@ RUN yum update -y \
     && ./configure --prefix=/usr --without-tcltk --with-curl \
     && make -s \
     && make install \
-    && yum remove -y gettext libcurl-devel \
+    && yum remove -y gettext zlib-devel openssl-devel libcurl-devel \
     && popd \
     && rm -rf /tmp/git-* \
-    && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
-    && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
-    && pushd /tmp/autoconf-2.69 \
-    && ./configure --prefix=/usr \
-    && make -s \
-    && make install \
-    && popd \
-    && rm -rf /tmp/autoconf-2.69* \
-    && wget -O /tmp/automake-1.16.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz \
-    && tar -zxf /tmp/automake-1.16.tar.gz -C /tmp \
-    && pushd /tmp/automake-1.16 \
-    && ./configure --prefix=/usr \
-    && sed -i "s/'none';/'reduce';/g" bin/automake.in \
-    && make -s \
-    && make install \
-    && popd \
-    && rm -rf /tmp/automake-1.16* \
     && wget -O /tmp/cmake-3.16.1-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.sh' \
     && bash /tmp/cmake-3.16.1-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
     && rm /tmp/cmake-3.16.1-Linux-x86_64.sh \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -16,30 +16,30 @@ ENV PATH=/opt/rh/rh-python36/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:${PA
 RUN yum update -y \
     && yum install -y centos-release-scl \
     && yum install -y \
-       sudo \
-       wget \
-       make \
+       autoconf \
+       autoconf-archive \
+       automake \
+       curl \
+       devtoolset-7-toolchain \
+       gettext \
        glibc-devel \
        glibc-devel.i686 \
-       libgcc.i686 \
-       nasm \
+       help2man \
+       libcurl-devel \
        libffi-devel \
+       libgcc.i686 \
+       libtool \
+       make \
+       nasm \
        openssl-devel \
        pkgconfig \
-       subversion \
-       zlib-devel \
-       xz \
-       curl \
-       tar \
-       devtoolset-7-toolchain \
        rh-python36 \
-       help2man \
-       autoconf-archive \
-       gettext \
-       libcurl-devel \
-       autoconf \
-       automake \
-       libtools \
+       subversion \
+       sudo \
+       tar \
+       wget \
+       xz \
+       zlib-devel \
     && yum clean all \
     && wget -O /tmp/git-2.22.0.tar.gz --no-check-certificate --quiet https://www.kernel.org/pub/software/scm/git/git-2.22.0.tar.gz \
     && tar -zxf /tmp/git-2.22.0.tar.gz -C /tmp \


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request

Add `libtool` to fix #162 
Replace downloaded `autoconf` and `automake` and replace with the versions installed from the distro (via yum) to fix https://github.com/conan-io/conan-center-index/issues/496

 Some `-devel` packages are removed since we are not building `autotools` from source..

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
