### PR TITLE
Build Conan tests images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,3 +157,7 @@ jobs:
 
       Conan Server:
         BUILD_CONAN_SERVER_IMAGE: 1
+
+      Conan Tests:
+        BUILD_CONAN_TESTS: 1
+        BUILD_CONAN_TEST_AZURE: 1

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -8,24 +8,24 @@ RUN dpkg --add-architecture i386 \
     && add-apt-repository ppa:deadsnakes/ppa -y \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       python3-dev=3.5.1-3 \
-       sudo=1.8.* \
+       python3-dev=3.* \
+       sudo=1.* \
        build-essential=12.* \
-       wget=1.17.* \
-       git=1:2.7.* \
-       libc6-dev-i386=2.23-* \
-       g++-multilib=4:5.3.* \
-       libgmp-dev=2:6.1.* \
-       libmpfr-dev=3.1.* \
-       libmpc-dev=1.0.* \
-       libc6-dev=2.23-* \
-       nasm=2.11.* \
+       wget=1.* \
+       git=1:* \
+       libc6-dev-i386=2.* \
+       g++-multilib=4:* \
+       libgmp-dev=2:* \
+       libmpfr-dev=3.* \
+       libmpc-dev=1.* \
+       libc6-dev=2.* \
+       nasm=2.* \
        dh-autoreconf=11 \
-       ninja-build=1.5.*  \
-       libffi-dev=3.2.* \
-       libssl-dev=1.0.2* \
-       pkg-config=0.29.1-0ubuntu1 \
-       subversion=1.9.3-2ubuntu1.1 \
+       ninja-build=1.*  \
+       libffi-dev=3.* \
+       libssl-dev=1.* \
+       pkg-config=0.* \
+       subversion=1.* \
        ca-certificates \
        python-software-properties \
        python3.4 \
@@ -38,6 +38,7 @@ RUN dpkg --add-architecture i386 \
        python3.5-dev \
        python3.6-dev \
        python3.7-dev \
+       python3.8-dev \
        golang \
        pkg-config \
        && rm -rf /var/lib/apt/lists/* \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -32,6 +32,7 @@ RUN dpkg --add-architecture i386 \
        python3.5 \
        python3.6 \
        python3.7 \
+       python3.8 \
        python-setuptools \
        python-dev \
        python3.4-dev \

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -18,6 +18,7 @@ RUN sudo apt-get update \
     python3.5-dev \
     python3.6-dev \
     python3.7-dev \
+    python3.8-dev \
     golang \
     pkg-config \
     && sudo rm -rf /var/lib/apt/lists/* \

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM conanio/gcc54
+FROM conanio/gcc5
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -12,6 +12,7 @@ RUN sudo apt-get update \
     python3.5 \
     python3.6 \
     python3.7 \
+    python3.8 \
     python-setuptools \
     python-dev \
     python3.4-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -712,3 +712,17 @@ services:
         image: "${DOCKER_USERNAME}/clang9-jnlp-slave-x86:${DOCKER_BUILD_TAG}"
         container_name: clang9-jnlp-slave-x86
         tty: true
+    conantests:
+        build:
+            context: conan_tests
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/conantests:${DOCKER_BUILD_TAG}"
+        container_name: conantests
+        tty: true
+    conantestazure:
+        build:
+            context: conan_test_azure
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/conantestazure:${DOCKER_BUILD_TAG}"
+        container_name: conan-test-azure
+        tty: true


### PR DESCRIPTION
There are 2 main different test images, but basically they are the same thing:

- conantests: It gets conanio/gcc5 and install python3-x
- conantestazure: Build an entire Docker image

Those images contain from Python-3.4 to Python-3.8 installed, but you need to configure what you want when running those containers:

    alias python=python3.8

Changelog: Feature: Build Conan test images and deploy

Related PR: #168 #153 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
