### PR TITLE
Install 'python3.8-distutils' too

### DIFF
--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -20,6 +20,7 @@ RUN sudo apt-get update \
     python3.6-dev \
     python3.7-dev \
     python3.8-dev \
+    python3.8-distutils \
     golang \
     pkg-config \
     && sudo rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
We need `virtualenv --python "/usr/bin/python3.8"` to work inside the image out of the box

Tip from here https://github.com/deadsnakes/issues/issues/82#issuecomment-478288319
