### PR TITLE
Meson is needed, Jenkins cannot install it

### DIFF
--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -28,7 +28,8 @@ RUN sudo apt-get update \
     && cd /tmp && wget https://bootstrap.pypa.io/get-pip.py \
     && sudo python3 get-pip.py \
     && sudo pip install virtualenv \
-    && pip3 install PyGithub
+    && pip3 install PyGithub \
+    && pip3 install meson
 
 USER conan
 WORKDIR /home/conan


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
