### PR TITLE
Install CMake via pip

### DIFF
--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -71,8 +71,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -72,7 +72,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -56,14 +56,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -80,7 +72,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -73,7 +73,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -57,14 +57,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -81,7 +73,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -59,14 +59,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -83,7 +75,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -74,8 +74,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -75,7 +75,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -73,7 +73,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -57,14 +57,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -81,7 +73,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -58,14 +58,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -82,7 +74,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -74,7 +74,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -73,8 +73,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -53,14 +53,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -77,7 +69,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -68,8 +68,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -70,7 +70,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -54,14 +54,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -78,7 +70,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -69,8 +69,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -66,8 +66,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -51,14 +51,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -75,7 +67,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -68,7 +68,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -67,8 +67,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -52,14 +52,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -76,7 +68,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -53,14 +53,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -77,7 +69,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -68,8 +68,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -70,7 +70,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -69,8 +69,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -54,14 +54,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -78,7 +70,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -66,8 +66,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -51,14 +51,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -75,7 +67,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -71,7 +71,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -55,14 +55,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -79,7 +71,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -70,8 +70,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -51,14 +51,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -75,7 +67,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -66,8 +66,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -68,7 +68,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -52,14 +52,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -76,7 +68,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -67,8 +67,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -47,5 +47,5 @@ RUN dpkg --add-architecture i386 \
        && python3 get-pip.py \
        && rm get-pip.py \
        && pip install -q -U pip \
-       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* --upgrade \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* --upgrade \
        && pip install virtualenv

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -47,5 +47,5 @@ RUN dpkg --add-architecture i386 \
        && python3 get-pip.py \
        && rm get-pip.py \
        && pip install -q -U pip \
-       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* --upgrade \
+       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* --upgrade \
        && pip install virtualenv

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -43,17 +43,9 @@ RUN dpkg --add-architecture i386 \
        golang \
        pkg-config \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.16.4-Linux-x86_64 \
-       && rm cmake-3.16.4-Linux-x86_64.tar.gz \
        && wget -q --no-check-certificate https://bootstrap.pypa.io/get-pip.py \
        && python3 get-pip.py \
        && rm get-pip.py \
        && pip install -q -U pip \
-       && pip install -q --no-cache-dir conan conan-package-tools --upgrade \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* --upgrade \
        && pip install virtualenv

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -34,13 +34,6 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /tmp/cmake-3.16.4-Linux-x86_64.tar.gz http://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf /tmp/cmake-3.16.4-Linux-x86_64.tar.gz -C /tmp \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR /tmp/cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf /tmp/cmake-3.16.4-Linux-x86_64* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -57,7 +50,7 @@ RUN apt-get -qq update \
     && pyenv install -v 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get -qq update \
     && pyenv install -v 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -49,8 +49,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && pyenv install -v 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -53,7 +53,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -36,14 +36,6 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -61,7 +53,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -52,8 +52,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -53,7 +53,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -36,14 +36,6 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -61,7 +53,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -52,8 +52,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -59,7 +59,7 @@ RUN dpkg --add-architecture armhf \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
     && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -60,7 +60,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -59,8 +59,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -43,14 +43,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -68,7 +60,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -43,14 +43,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -68,7 +60,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -60,7 +60,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -59,8 +59,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
     && pyenv global 3.6.7 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -54,8 +54,8 @@ RUN apt-get -qq update \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
-       && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+       && pip install -q --upgrade --no-cache-dir pip scikit-build \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -39,14 +39,6 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-       && tar -xzf cmake-3.16.4.tar.gz \
-       && cd cmake-3.16.4 \
-       && ./bootstrap > /dev/null \
-       && make -s -j`nproc` \
-       && make -s install > /dev/null \
-       && cd - \
-       && rm -rf cmake-* \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \
@@ -63,7 +55,7 @@ RUN apt-get -qq update \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -qq update \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -52,8 +52,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -37,14 +37,6 @@ RUN dpkg --add-architecture i386 \
     ca-certificates \
     autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -61,7 +53,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -53,7 +53,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -102,8 +102,8 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.5 \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -103,7 +103,7 @@ RUN dpkg --add-architecture i386 \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -85,14 +85,6 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && ln -s /usr/bin/g++-5 /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.14/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -111,7 +103,7 @@ RUN dpkg --add-architecture i386 \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -55,7 +55,7 @@ RUN dpkg --add-architecture i386 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -39,14 +39,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.16.4-Linux-x86_64 \
-       && rm cmake-3.16.4-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \
@@ -63,7 +55,7 @@ RUN dpkg --add-architecture i386 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -54,8 +54,8 @@ RUN dpkg --add-architecture i386 \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
-       && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+       && pip install -q --upgrade --no-cache-dir pip scikit-build \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -55,7 +55,7 @@ RUN dpkg --add-architecture i386 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -39,14 +39,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-          --exclude=bin/cmake-gui \
-          --exclude=doc/cmake \
-          --exclude=share/cmake-3.12/Help \
-       && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-       && rm -rf cmake-3.16.4-Linux-x86_64 \
-       && rm cmake-3.16.4-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \
@@ -63,7 +55,7 @@ RUN dpkg --add-architecture i386 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
        && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -54,8 +54,8 @@ RUN dpkg --add-architecture i386 \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
-       && pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+       && pip install -q --upgrade --no-cache-dir pip scikit-build \
+       && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -48,14 +48,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -72,7 +64,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -63,8 +63,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -56,8 +56,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -57,7 +57,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -41,14 +41,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -65,7 +57,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -56,8 +56,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -57,7 +57,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -41,14 +41,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -65,7 +57,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -46,14 +46,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -70,7 +62,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -62,7 +62,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -61,8 +61,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -62,8 +62,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -63,7 +63,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -47,14 +47,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -71,7 +63,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -97,7 +97,7 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -96,8 +96,8 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \

--- a/gcc_7-centos6-x86/Dockerfile
+++ b/gcc_7-centos6-x86/Dockerfile
@@ -85,14 +85,6 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && make install > /dev/null \
     && popd \
     && rm -rf /tmp/openssl-* /tmp/OpenSSL* \
-    && wget --no-check-certificate --quiet -O /tmp/cmake-3.16.4.tar.gz https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf /tmp/cmake-3.16.4.tar.gz -C /tmp \
-    && pushd /tmp/cmake-3.16.4 \
-    && ./bootstrap \
-    && make -s -j`nproc` > /dev/null \
-    && make -s install > /dev/null \
-    && popd \
-    && rm -rf /tmp/cmake-* \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
@@ -105,7 +97,7 @@ RUN printf "i686" >  /etc/yum/vars/arch \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir conan \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -69,11 +69,8 @@ RUN yum update -y \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-    && wget -O /tmp/cmake-3.16.4-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.sh' \
-    && bash /tmp/cmake-3.16.4-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
-    && rm /tmp/cmake-3.16.4-Linux-x86_64.sh \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -69,8 +69,8 @@ RUN yum update -y \
     && make install \
     && popd \
     && rm -rf /tmp/automake-1.16* \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \

--- a/gcc_7-centos6/Dockerfile
+++ b/gcc_7-centos6/Dockerfile
@@ -70,7 +70,7 @@ RUN yum update -y \
     && popd \
     && rm -rf /tmp/automake-1.16* \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
     && groupadd 1001 -g 1001 \
     && useradd -ms /bin/bash conan -g 1001 -G wheel \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -63,8 +63,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -48,14 +48,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -72,7 +64,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -59,8 +59,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -60,7 +60,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -44,14 +44,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -68,7 +60,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -45,14 +45,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -69,7 +61,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -61,7 +61,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -60,8 +60,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -61,8 +61,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -46,14 +46,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -70,7 +62,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -45,14 +45,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -69,7 +61,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -61,7 +61,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -60,8 +60,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -61,8 +61,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -46,14 +46,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
-    && tar -xzf cmake-3.16.4.tar.gz \
-    && cd cmake-3.16.4 \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -70,7 +62,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -61,7 +61,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
+    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -45,14 +45,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.16.4-Linux-x86_64 \
-    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -69,7 +61,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -60,8 +60,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
-    && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools scikit-build cmake==3.16.* \
+    && pip install -q --upgrade --no-cache-dir pip scikit-build \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.* \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/update_cmake.py
+++ b/update_cmake.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 import os
 
 if __name__ == "__main__":
 
-    for old, new in [("3.16.1", "3.16.4"), ("v3.16", "v3.16")]:
+    old = "cmake==3.15.*"
+    new = "cmake==3.16.*"
 
-        for root, _, filenames in os.walk("./"):
-            for filename in filenames:
-                if filename == "Dockerfile":
-                    path = os.path.join(root, filename)
-                    with open(path) as file:
-                        data = file.read()
+    for root, _, filenames in os.walk("./"):
+        for filename in filenames:
+            if filename == "Dockerfile":
+                path = os.path.join(root, filename)
+                with open(path) as file:
+                    data = file.read()
 
-                    data = data.replace(old, new)
+                data = data.replace(old, new)
 
-                    with open(path, "w") as file:
-                        file.write(data)
+                with open(path, "w") as file:
+                    file.write(data)


### PR DESCRIPTION
Changelog: Feature: Install CMake via pip

This simplifies the installation of CMake a lot. In fact, different containers used different line of codes and weren't always up to date (like excluding paths which don't exist in the current used CMake version).

Bincrafters' CI uses CMake via pip for a long time and personally that is how I'm managing my CMake installations as well on Fedora and Windows.


