### PR TITLE
Add Clang 10 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can use these images directly in your project or with the [conan-package-too
 > :warning: **Warning:**
 The images listed below are intended for **generating open-source library packages** and we cannot guarantee any kind of stability. We strongly recommend using your own generated images for production environments taking the dockerfiles in this repository as a reference.
 
-The images are uploaded to Dockerhub:
+The images are uploaded to Docker Hub:
 
 #### GCC
 | Version                                                                                       | Arch    |  Status, Life cycle  |
@@ -76,6 +76,7 @@ GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are
 | - [conanio/clang8: clang 8](https://hub.docker.com/r/conanio/clang8/)                 | x86_64 |  Supported |
 | - [conanio/clang9-x86: clang 9](https://hub.docker.com/r/conanio/clang9-x86/)         | x86    |  Supported |
 | - [conanio/clang9: clang 9](https://hub.docker.com/r/conanio/clang9/)                 | x86_64 |  Supported |
+| - [conanio/clang10: clang 10](https://hub.docker.com/r/conanio/clang10/)              | x86_64 |  Supported |
 
 
 #### Visual Studio
@@ -83,6 +84,7 @@ GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are
 We can not re-distribute Windows docker images, since Visual Studio Build Tools is licensed as supplemental license for Visual Studio.
 To have more information about: https://github.com/Microsoft/vs-dockerfiles#samples
 However, you can download the Docker recipe and build.
+
 
 #### Android
 
@@ -93,6 +95,7 @@ However, you can download the Docker recipe and build.
 | - [conanio/android-clang8-armv7: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-armv7/) | x86    |  Supported |
 | - [conanio/android-clang8-armv8: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-armv8/) | x86    |  Supported |
 
+
 #### Conan Server
 
 Conan Docker Tools provides an image version with only Conan Server installed, very useful for the cases it is necessary to run a server without touching the host.
@@ -101,16 +104,17 @@ Conan Docker Tools provides an image version with only Conan Server installed, v
 |-----------------------------------------------------------------------------------------------|--------|------------|
 | - [conanio/conan_server](https://hub.docker.com/r/conanio/conan_server/)             | ANY |  Supported |
 
+
 #### Conan Installer
 
 **conanio/gcc7-centos6** is a special image version based on CentOS 6, GCC 7 and **glibc 2.12** (very old glibc version). This is intended to build executables that run almost on any Linux because **glibc** guarantees backward compatibility. You can use this image to build your Conan build tools packages (`build_requires`). This image is **ONLY** able to build **x86_64** binaries.
 
 **conanio/gcc7-centos6-x86** is a special image version based on CentOS 6 i386, GCC 7 and **glibc 2.12** (very old glibc version). This is intended to build executables that run almost on any Linux because **glibc** guarantees backward compatibility. You can use this image to build your Conan build tools packages (`build_requires`). This image is **ONLY** able to build **x86** binaries.
 
-Use the images to test your c++ project in travis-ci
+Use the images to test your C++ project in Travis CI
 ======================================================
 
-These Docker images can be used to build your project using the travis-ci CI service, even if you are not using Conan.
+These Docker images can be used to build your project using the Travis CI CI service, even if you are not using Conan.
 It's always recommended to build and test your C/C++ projects in a Docker image running in travis:
 
 - Travis CI images are old, so installing a newer version of gcc and the needed tools can be hard. Check [this thread](https://github.com/travis-ci/travis-ci/issues/6300).
@@ -133,13 +137,13 @@ You need to modify:| [conanio/gcc5-jnlp-slave: gcc 4.6](https://hub.docker.com/r
     language: python
     env:
       matrix:
-        - DOCKER_IMAGE=conanio/gcc63 # 6.3
-        - DOCKER_IMAGE=conanio/clang39 # 3.9
+        - DOCKER_IMAGE=conanio/gcc8 # GCC 8.x
+        - DOCKER_IMAGE=conanio/clang7 # Clang 7
 
     matrix:
        include:
            - os: osx
-             osx_image: xcode8.2 # apple-clang 8.0
+             osx_image: xcode11.3 # Apple-Clang 11.0
              language: generic
              env:
 
@@ -214,7 +218,7 @@ If you use Jenkins to build your packages and also you use Jenkins Slave to run 
 | - [conanio/clang8-jnlp-slave: clang 8](https://hub.docker.com/r/conanio/clang8-jnlp-slave/)                 | x86_64 |  Supported |
 | - [conanio/clang8-jnlp-slave-x86: clang 9](https://hub.docker.com/r/conanio/clang9-jnlp-slave-x86/)         | x86    |  Supported |
 | - [conanio/clang8-jnlp-slave: clang 9](https://hub.docker.com/r/conanio/clang9-jnlp-slave/)                 | x86_64 |  Supported |
-
+| - [conanio/clang8-jnlp-slave: clang 10](https://hub.docker.com/r/conanio/clang10-jnlp-slave/)               | x86_64 |  Supported |
 
 
 
@@ -251,14 +255,14 @@ The script *build.py* will build, test and deploy your Docker image. You can con
 
 Also, you can build only a version:
 
-E.g Build and test only a image with Conan and gcc-6.3
+E.g Build and test only a image with Conan and gcc-6
 ```
-$ CONAN_GCC_VERSIONS="6.3" python build.py
+$ CONAN_GCC_VERSIONS="6" python build.py
 ```
 
-E.g Build and test only the images with Conan and clang-4.0, clang-3.9
+E.g Build and test only the images with Conan and clang-8, clang-9
 ```
-$ CONAN_CLANG_VERSIONS="3.9,4.0" python build.py
+$ CONAN_CLANG_VERSIONS="8,9" python build.py
 ```
 
 E.g Build and test only the images with Conan and Visual Studio 14.0 (It **ONLY** works on Windows).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,6 +149,9 @@ jobs:
         CLANG_VERSIONS: "9"
         DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
+      Ubuntu Clang 10 x86_64:
+        CLANG_VERSIONS: "10"
+        DOCKER_DISTRO: "jnlp-slave"
 
       Android Clang 8:
         DOCKER_CROSS: "android"

--- a/build.py
+++ b/build.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Build, Test and Deploy Docker images for Conan project"""
 import collections
 import os
@@ -199,13 +198,13 @@ class ConanDockerTools(object):
         subprocess.check_call("docker exec %s %s pip -q install -U conan_package_tools" % (self.service, self.variables.sudo_command), shell=True)
         subprocess.check_call("docker exec %s conan user" % self.service, shell=True)
 
-        subprocess.check_call('docker exec %s conan install lz4/1.8.3@bincrafters/stable -s '
+        subprocess.check_call('docker exec %s conan install lz4/1.9.2@ -s '
                             'arch=%s -s compiler="%s" -s compiler.version=%s '
                             '-s compiler.runtime=MD --build' %
                             (self.service, arch, compiler_name,
                             compiler_version), shell=True)
 
-        subprocess.check_call('docker exec %s conan install gtest/1.8.1@bincrafters/stable -s '
+        subprocess.check_call('docker exec %s conan install gtest/1.10.0@ -s '
                             'arch=%s -s compiler="%s" -s compiler.version=%s '
                             '-s compiler.runtime=MD --build' %
                             (self.service, arch, compiler_name,
@@ -268,14 +267,14 @@ class ConanDockerTools(object):
                 compiler_version = "7.0"  # FIXME: Remove this when fixed in conan
 
         subprocess.check_call(
-            "docker exec %s conan install lz4/1.8.3@bincrafters/stable -s "
+            "docker exec %s conan install lz4/1.9.2@ -s "
             "arch=%s -s compiler=%s -s compiler.version=%s --build" %
             (self.service, arch, compiler_name, compiler_version),
             shell=True)
 
         for libcxx in libcxx_list:
             subprocess.check_call(
-                "docker exec %s conan install gtest/1.8.1@bincrafters/stable -s "
+                "docker exec %s conan install gtest/1.10.0@ -s "
                 "arch=%s -s compiler=%s -s compiler.version=%s "
                 "-s compiler.libcxx=%s --build" % (self.service, arch, compiler_name,
                                                 compiler_version, libcxx),

--- a/build.py
+++ b/build.py
@@ -204,7 +204,7 @@ class ConanDockerTools(object):
                             (self.service, arch, compiler_name,
                             compiler_version), shell=True)
 
-        subprocess.check_call('docker exec %s conan install gtest/1.10.0@ -s '
+        subprocess.check_call('docker exec %s conan install gtest/1.8.1@ -s '
                             'arch=%s -s compiler="%s" -s compiler.version=%s '
                             '-s compiler.runtime=MD --build' %
                             (self.service, arch, compiler_name,
@@ -274,7 +274,7 @@ class ConanDockerTools(object):
 
         for libcxx in libcxx_list:
             subprocess.check_call(
-                "docker exec %s conan install gtest/1.10.0@ -s "
+                "docker exec %s conan install gtest/1.8.1@ -s "
                 "arch=%s -s compiler=%s -s compiler.version=%s "
                 "-s compiler.libcxx=%s --build" % (self.service, arch, compiler_name,
                                                 compiler_version, libcxx),
@@ -318,8 +318,8 @@ class ConanDockerTools(object):
             subprocess.check_call("docker run -t -d --name %s %s" % (self.service,
                 self.created_image_name), shell=True)
             output = subprocess.check_output(
-                "docker exec %s conan install -r conan-center zlib/1.2.11@conan/stable" % (self.service), shell=True)
-            assert "zlib/1.2.11@conan/stable: Package installed" in output.decode()
+                "docker exec %s conan install -r conan-center zlib/1.2.11@" % (self.service), shell=True)
+            assert "zlib/1.2.11: Package installed" in output.decode()
         finally:
             subprocess.call("docker stop %s" % self.service, shell=True)
             subprocess.call("docker rm %s" % self.service, shell=True)

--- a/clang_10/.dockerignore
+++ b/clang_10/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -1,51 +1,59 @@
-FROM ubuntu:focal
+FROM ubuntu:bionic
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV LLVM_VERSION=10.0 \
+ENV LLVM_VERSION=10 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
     CMAKE_CXX_COMPILER=clang++ \
     PYENV_ROOT=/opt/pyenv \
-    PATH=/opt/pyenv/shims:${PATH}
+    PYTHON_VERSION=3.8.2 \
+    PATH=/opt/pyenv/shims:${PATH} \
+    CMAKE_VERSION_MAJOR_MINOR=3.17 \
+    CMAKE_VERSION_FULL=3.17.1
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
+    # Install basics
     && apt-get install -y --no-install-recommends \
-       sudo=1.* \
-       wget=1.* \
-       git=1:2.* \
-       subversion=1.* \
-       g++-10-multilib \
-       clang-10=1:10* \
-       make=4.* \
-       libc6-dev-i386=2.* \
-       # libgmp-dev=2:6.* \
-       # libmpfr-dev=4.* \
-       # libmpc-dev=1.* \
-       dh-autoreconf=19 \
-       libc++-dev=1:9.* \
-       libc++abi-dev=1:9.* \
-       gnupg=2.* \
+       sudo \
+       wget \
+       git \
+       subversion \
+       make \
+       gnupg \
        ca-certificates \
-       # Dependencies of Python
-       libreadline-dev=8.* \
-       libsqlite3-dev=3.* \
-       libffi-dev=3.* \
-       libssl-dev=1* \
-       zlib1g-dev=1:1.* \
-       libbz2-dev=1.* \
-       xz-utils=5.* \
-       curl=7.* \
-       libncurses5-dev=6.* \
-       libncursesw5-dev=6.* \
-       liblzma-dev=5.* \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 \
-    && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-10 100 \
+       dh-autoreconf \
+    # Install compiler toolset
+    && apt-get install -y --no-install-recommends \
+       lsb-release \ 
+       software-properties-common \
+    && wget https://apt.llvm.org/llvm.sh \ 
+    && chmod +x llvm.sh \
+    && sudo ./llvm.sh ${LLVM_VERSION} \
+    && rm llvm.sh \
+    && apt-get remove -y lsb-release software-properties-common \
+    # Install dependencies of Python
+    && apt-get install -y --no-install-recommends \
+       libreadline-dev \
+       libsqlite3-dev \
+       libffi-dev \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       xz-utils \
+       curl \
+       libncurses5-dev \
+       libncursesw5-dev \
+       liblzma-dev \
+    && apt-get clean all \
+    # Update default compiler
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd 1001 -g 1001 \
@@ -61,10 +69,10 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.2 \
-    && pyenv global 3.8.2 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
+    && pyenv global ${PYTHON_VERSION} \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.3 \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION_MAJOR_MINOR} \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -47,6 +47,7 @@ RUN dpkg --add-architecture i386 \
        libncurses5-dev \
        libncursesw5-dev \
        liblzma-dev \
+    && apt-get autoremove -y \
     && apt-get clean all \
     # Update default compiler
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100 \

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -33,6 +33,10 @@ RUN dpkg --add-architecture i386 \
     && chmod +x llvm.sh \
     && sudo ./llvm.sh ${LLVM_VERSION} \
     && rm llvm.sh \
+    # Further LLVM packages not installed by the llvm.sh script
+    && apt-get install -y --no-install-recommends \
+       libc++-10-dev \
+       libc++abi-10-dev \
     && apt-get remove -y lsb-release software-properties-common \
     # Install dependencies of Python
     && apt-get install -y --no-install-recommends \

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -10,8 +10,7 @@ ENV LLVM_VERSION=10 \
     PYENV_ROOT=/opt/pyenv \
     PYTHON_VERSION=3.8.2 \
     PATH=/opt/pyenv/shims:${PATH} \
-    CMAKE_VERSION_MAJOR_MINOR=3.17 \
-    CMAKE_VERSION_FULL=3.17.1
+    CMAKE_VERSION=3.16.6
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
@@ -77,7 +76,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION_MAJOR_MINOR} \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION} \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -1,0 +1,81 @@
+FROM ubuntu:focal
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV LLVM_VERSION=10.0 \
+    CC=clang \
+    CXX=clang++ \
+    CMAKE_C_COMPILER=clang \
+    CMAKE_CXX_COMPILER=clang++ \
+    PYENV_ROOT=/opt/pyenv \
+    PATH=/opt/pyenv/shims:${PATH}
+
+RUN dpkg --add-architecture i386 \
+    && apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       subversion=1.* \
+       g++-10-multilib \
+       clang-10=1:10* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       # libgmp-dev=2:6.* \
+       # libmpfr-dev=4.* \
+       # libmpc-dev=1.* \
+       dh-autoreconf=19 \
+       libc++-dev=1:9.* \
+       libc++abi-dev=1:9.* \
+       gnupg=2.* \
+       ca-certificates \
+       # Dependencies of Python
+       libreadline-dev=8.* \
+       libsqlite3-dev=3.* \
+       libffi-dev=3.* \
+       libssl-dev=1* \
+       zlib1g-dev=1:1.* \
+       libbz2-dev=1.* \
+       xz-utils=5.* \
+       curl=7.* \
+       libncurses5-dev=6.* \
+       libncursesw5-dev=6.* \
+       liblzma-dev=5.* \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 \
+    && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-10 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd 1001 -g 1001 \
+    && groupadd 1000 -g 1000 \
+    && groupadd 2000 -g 2000 \
+    && groupadd 999 -g 999 \
+    && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
+    && printf "conan:conan" | chpasswd \
+    && adduser conan sudo \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && chmod +x /tmp/pyenv-installer \
+    && /tmp/pyenv-installer \
+    && rm /tmp/pyenv-installer \
+    && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.2 \
+    && pyenv global 3.8.2 \
+    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan conan-package-tools cmake==3.16.3 \
+    && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+
+USER conan
+WORKDIR /home/conan
+
+RUN mkdir -p /home/conan/.conan \
+    && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \
+    && printf 'eval "$(pyenv virtualenv-init -)"\n' >> ~/.bashrc

--- a/clang_10/build.sh
+++ b/clang_10/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker build --no-cache -t conanio/clang10 .

--- a/clang_10/run.sh
+++ b/clang_10/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker run --rm -v ~/.conan/data:/home/conan/.conan/data -it conanio/clang10 /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -719,6 +719,15 @@ services:
         image: "${DOCKER_USERNAME}/clang9-jnlp-slave-x86:${DOCKER_BUILD_TAG}"
         container_name: clang9-jnlp-slave-x86
         tty: true
+    clang10-jnlp-slave:
+        build:
+            context: jenkins-jnlp-slave
+            dockerfile: Dockerfile
+            args:
+                SOURCE_CONANIO_IMAGE: conanio/clang10
+        image: "${DOCKER_USERNAME}/clang10-jnlp-slave:${DOCKER_BUILD_TAG}"
+        container_name: clang10-jnlp-slave
+        tty: true
     conantests:
         build:
             context: conan_tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -400,6 +400,13 @@ services:
         image: "${DOCKER_USERNAME}/clang9-x86:${DOCKER_BUILD_TAG}"
         container_name: clang9-x86
         tty: true
+    clang10:
+        build:
+            context: clang_10
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/clang10:${DOCKER_BUILD_TAG}"
+        container_name: clang10
+        tty: true
     msvc14:
         build:
             context: msvc_14


### PR DESCRIPTION
Changelog: Feature: Add Clang 10 container image

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.

__________________________________

I decided to go with the upstream LLVM APT repository this time, as they offer builds for older LTS versions of Ubuntu too.

Ubuntu itself is currently only offering Clang 10 binaries for Ubuntu 20.04. Using this would mean a brand new glibc version which causes that the built binaries are compatible with just very few distribution versions out there....

Ubuntu Bionic seems currently to be a fair compromise between not too old and not too new.

I also re-structured the Dockerfile a little bit differently compared to previous Clang containers, so that it is more clear what packages are installed why.

LLVM, Python and CMake versions are now also specified via environment variables at the beginning of the Dockerfile. Making it easier to read/maintain those.

Additional things that I did not want to split up in other pull requests:
  * Using recipes from CCI instead the old ones for testing
  * Update README examples with more up-to-date compiler versions
