### PR TITLE
Add centos7-gcc9 docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are
 | [conanio/gcc9: gcc 9](https://hub.docker.com/r/conanio/gcc9/)                      | x86_64  |  Supported           |
 | [conanio/gcc9-armv7: gcc 9](https://hub.docker.com/r/conanio/gcc9-armv7/)          | armv7   |  Supported           |
 | [conanio/gcc9-armv7hf: gcc 9](https://hub.docker.com/r/conanio/gcc9-armv7hf/)      | armv7hf |  Supported           |
+| [conanio/gcc9-centos7: gcc 9](https://hub.docker.com/r/conanio/gcc9-centos7/)      | x86_64  |  Supported           |
 | [conanio/gcc10: gcc 10](https://hub.docker.com/r/conanio/gcc10/)                   | x86_64  |  Supported           |
 | [conanio/gcc10-armv7: gcc 10](https://hub.docker.com/r/conanio/gcc10-armv7/)       | armv7   |  Supported           |
 | [conanio/gcc10-armv7hf: gcc 10](https://hub.docker.com/r/conanio/gcc10-armv7hf/)   | armv7hf |  Supported           |
@@ -113,6 +114,8 @@ Conan Docker Tools provides an image version with only Conan Server installed, v
 **conanio/gcc7-centos6** is a special image version based on CentOS 6, GCC 7 and **glibc 2.12** (very old glibc version). This is intended to build executables that run almost on any Linux because **glibc** guarantees backward compatibility. You can use this image to build your Conan build tools packages (`build_requires`). This image is **ONLY** able to build **x86_64** binaries.
 
 **conanio/gcc7-centos6-x86** is a special image version based on CentOS 6 i386, GCC 7 and **glibc 2.12** (very old glibc version). This is intended to build executables that run almost on any Linux because **glibc** guarantees backward compatibility. You can use this image to build your Conan build tools packages (`build_requires`). This image is **ONLY** able to build **x86** binaries.
+
+**conanio/gcc9-centos7** is a special image version based on CentOS 7, GCC 9 and **glibc 2.17** (very old glibc version). This is intended to build executables that run almost on any Linux because **glibc** guarantees backward compatibility. You can use this image to build your Conan build tools packages (`build_requires`). This image is **ONLY** able to build **x86_64** binaries.
 
 Use the images to test your C++ project in Travis CI
 ======================================================
@@ -201,6 +204,7 @@ If you use Jenkins to build your packages and also you use Jenkins Slave to run 
 | [conanio/gcc10-jnlp-slave: gcc 10](https://hub.docker.com/r/conanio/gcc10-jnlp-slave/)        | x86_64  |  Supported |
 | [conanio/gcc7-jnlp-slave-centos6: gcc 7](https://hub.docker.com/r/conanio/gcc7-jnlp-slave-centos6/)        | x86_64  |  Supported |
 | [conanio/gcc7-jnlp-slave-centos6-x86: gcc 7](https://hub.docker.com/r/conanio/gcc7-jnlp-slave-centos6-x86/)  | x86  |  Supported |
+| [conanio/gcc9-jnlp-slave-centos7: gcc 9](https://hub.docker.com/r/conanio/gcc9-jnlp-slave-centos7/)        | x86_64  |  Supported |
 
 
 #### Clang

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,10 @@ jobs:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "centos6,jnlp-slave-centos6"
+      CentOS 7 GCC 9 x86_64:
+        GCC_VERSIONS: "9"
+        DOCKER_ARCHS: "x86_64"
+        DOCKER_DISTRO: "centos7,jnlp-slave-centos7"
       Ubuntu MinGW GCC 7 x86_64:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -408,6 +408,13 @@ services:
         image: "${DOCKER_USERNAME}/gcc7-centos6-x86:${DOCKER_BUILD_TAG}"
         container_name: gcc7-centos6-x86
         tty: true
+    gcc9-centos7:
+        build:
+            context: gcc_9-centos7
+            dockerfile: Dockerfile
+        image: "${DOCKER_USERNAME}/gcc9-centos7:${DOCKER_BUILD_TAG}"
+        container_name: gcc9-centos7
+        tty: true
     clang8:
         build:
             context: clang_8
@@ -629,6 +636,14 @@ services:
                 SOURCE_CONANIO_IMAGE: conanio/gcc7-centos6-x86
         image: "${DOCKER_USERNAME}/gcc7-jnlp-slave-centos6-x86:${DOCKER_BUILD_TAG}"
         container_name: gcc7-jnlp-slave-centos6-x86
+    gcc9-jnlp-slave-centos7:
+        build:
+            context: jenkins-jnlp-slave
+            dockerfile: centos7/Dockerfile
+            args:
+                SOURCE_CONANIO_IMAGE: conanio/gcc9-centos7
+        image: "${DOCKER_USERNAME}/gcc9-jnlp-slave-centos7:${DOCKER_BUILD_TAG}"
+        container_name: gcc9-jnlp-slave-centos7
     clang39-jnlp-slave:
         build:
             context: jenkins-jnlp-slave

--- a/gcc_9-centos7/.dockerignore
+++ b/gcc_9-centos7/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/gcc_9-centos7/Dockerfile
+++ b/gcc_9-centos7/Dockerfile
@@ -1,0 +1,76 @@
+FROM centos:7
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV PATH=/opt/rh/rh-python36/root/usr/bin:/opt/rh/devtoolset-9/root/usr/bin:/opt/rh/rh-perl526/root/usr/local/bin:/opt/rh/rh-perl526/root/usr/bin:/opt/rh/sclo-git25/root/usr/bin:${PATH:+:${PATH}} \
+    MANPATH=/opt/rh/rh-python36/root/usr/share/man:/opt/rh/devtoolset-9/root/usr/share/man:/opt/rh/rh-perl526/root/usr/share/man:/opt/rh/sclo-git25/root/usr/share/man:${MANPATH:+:${MANPATH}} \
+    INFOPATH=/opt/rh/devtoolset-9/root/usr/share/info${INFOPATH:+:${INFOPATH}} \
+    PCP_DIR=/opt/rh/devtoolset-9/root \
+    PERL5LIB=/opt/rh/devtoolset-9/root/usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-9/root/usr/lib/perl5:/opt/rh/devtoolset-9/root//usr/share/perl5/vendor_perl:/opt/rh/sclo-git25/root/usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}} \
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/opt/rh/rh-python36/root/usr/lib64:/opt/rh/rh-perl526/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    PKG_CONFIG_PATH=/opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS="/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
+    CXX=/opt/rh/devtoolset-9/root/usr/bin/g++ \
+    CC=/opt/rh/devtoolset-9/root/usr/bin/gcc
+
+RUN yum update -y \
+    && yum install -y centos-release-scl \
+    && yum install -y \
+       sudo \
+       wget \
+       make \
+       glibc-devel \
+       glibc-devel.i686 \
+       libgcc.i686 \
+       gmp-devel \
+       mpfr-devel \
+       libmpc-devel \
+       nasm \
+       m4 \
+       libffi-devel \
+       openssl-devel \
+       pkgconfig \
+       subversion \
+       zlib-devel \
+       xz \
+       curl \
+       xz-devel \
+       tar \
+       devtoolset-9-toolchain \
+       rh-python36 \
+       rh-perl526 \
+       sclo-git25 \
+       help2man \
+       autoconf-archive \
+    && yum clean all \
+    && wget -O /tmp/autoconf-2.69.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
+    && tar -zxf /tmp/autoconf-2.69.tar.gz -C /tmp \
+    && pushd /tmp/autoconf-2.69 \
+    && ./configure --prefix=/usr \
+    && make -s \
+    && make install \
+    && popd \
+    && rm -rf /tmp/autoconf-2.69* \
+    && wget -O /tmp/automake-1.16.tar.gz --no-check-certificate --quiet https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz \
+    && tar -zxf /tmp/automake-1.16.tar.gz -C /tmp \
+    && pushd /tmp/automake-1.16 \
+    && ./configure --prefix=/usr \
+    && sed -i "s/'none';/'reduce';/g" bin/automake.in \
+    && make -s \
+    && make install \
+    && popd \
+    && rm -rf /tmp/automake-1.16* \
+    && wget -O /tmp/cmake-3.17.3-Linux-x86_64.sh --no-check-certificate --quiet 'https://cmake.org/files/v3.17/cmake-3.17.3-Linux-x86_64.sh' \
+    && bash /tmp/cmake-3.17.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir \
+    && rm /tmp/cmake-3.17.3-Linux-x86_64.sh \
+    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan conan-package-tools \
+    && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
+    && groupadd conan -g 1001 \
+    && useradd -ms /bin/bash conan -g conan -u 1001 -G wheel \
+    && printf "conan:conan" | chpasswd \
+    && chgrp -R wheel /opt/rh/rh-python36/root \
+    && chmod -R g+w -R /opt/rh/rh-python36/root
+
+USER conan
+WORKDIR /home/conan

--- a/jenkins-jnlp-slave/README.md
+++ b/jenkins-jnlp-slave/README.md
@@ -11,7 +11,9 @@ docker build -t conanio/jnlp-slave-gcc46 --build-arg SOURCE_CONANIO_IMAGE=conani
 docker build -t conanio/jnlp-slave-gcc8 --build-arg SOURCE_CONANIO_IMAGE=conanio/gcc8 .
 docker build -t conanio/jnlp-slave-gcc7-centos6 --build-arg SOURCE_CONANIO_IMAGE=conanio/gcc7-centos6 --file centos6/Dockerfile .
 docker build -t conanio/jnlp-slave-gcc7-centos6-x86 --build-arg SOURCE_CONANIO_IMAGE=conanio/gcc7-centos6-x86 --file centos6/Dockerfile .
+docker build -t conanio/jnlp-slave-gcc9-centos7 --build-arg SOURCE_CONANIO_IMAGE=conanio/gcc9-centos7 --file centos7/Dockerfile .
 
 **Note**: This Dockerfile ie: 'jenkins-jnlp-slave/Dockerfile' can not process following dockerhub conanio images. Use the Dockerfile mentioned in corresponding brackets.
 - conanio/gcc7-centos6  (Use jenkins-jnlp-slave/centos6/Dockerfile)
 - conanio/gcc7-centos6-x86  (Use jenkins-jnlp-slave/centos6/Dockerfile)
+- conanio/gcc9-centos7  (Use jenkins-jnlp-slave/centos7/Dockerfile)

--- a/jenkins-jnlp-slave/centos7/Dockerfile
+++ b/jenkins-jnlp-slave/centos7/Dockerfile
@@ -1,0 +1,22 @@
+ARG SOURCE_CONANIO_IMAGE
+FROM $SOURCE_CONANIO_IMAGE
+
+ARG AGENT_VERSION=3.27
+USER root
+
+COPY jenkins-slave /usr/local/bin/jenkins-slave
+COPY entrypoint.sh /opt/entrypoint.sh
+
+RUN yum install -y \
+    java-1.8.0-openjdk \
+    curl \
+    && yum clean all \
+    && pip install --no-cache virtualenv \
+    && curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${AGENT_VERSION}/remoting-${AGENT_VERSION}.jar \
+    && chmod +x /opt/entrypoint.sh \
+    && chmod +x /usr/local/bin/jenkins-slave \
+    && chmod 755 /usr/share/jenkins \
+    && chmod 644 /usr/share/jenkins/slave.jar
+
+ENTRYPOINT ["/opt/entrypoint.sh"]
+USER conan


### PR DESCRIPTION
Changelog: Feature: Add support for a centos7 image with GCC 9 compiler
closes #206 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
