### PR TITLE
Add android-clang9 with NDK 21

### DIFF
--- a/android-clang_9-armv7/.dockerignore
+++ b/android-clang_9-armv7/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/android-clang_9-armv7/Dockerfile
+++ b/android-clang_9-armv7/Dockerfile
@@ -1,0 +1,23 @@
+FROM conanio/android-clang9
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV ANDROID_ABI=armeabi-v7a \
+    ANDROID_PLATFORM=android-16 \
+    CC=$STANDALONE_TOOLCHAIN/bin/armv7a-linux-androideabi16-clang \
+    CXX=$STANDALONE_TOOLCHAIN/bin/armv7a-linux-androideabi16-clang++ \
+    LD=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-ld \
+    AR=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-ar \
+    AS=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-as \
+    RANLIB=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-ranlib \
+    STRIP=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-strip \
+    ADDR2LINE=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-addr2line \
+    NM=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-nm \
+    OBJCOPY=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-objcopy \
+    OBJDUMP=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-objdump \
+    READELF=$STANDALONE_TOOLCHAIN/bin/arm-linux-androideabi-readelf
+
+RUN conan profile update settings.arch=armv7 default \
+    && conan profile update settings.os=Android default \
+    && conan profile update settings.os.api_level=16 default \
+    && conan profile update settings.compiler.libcxx=libc++ default

--- a/android-clang_9-armv7/build.sh
+++ b/android-clang_9-armv7/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker build --no-cache -t conanio/android-clang9-armv7 .

--- a/android-clang_9-armv7/run.sh
+++ b/android-clang_9-armv7/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker run --rm -v ~/.conan/data:/home/conan/.conan/data -it conanio/android-clang9-armv7 /bin/bash

--- a/android-clang_9-armv8/.dockerignore
+++ b/android-clang_9-armv8/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/android-clang_9-armv8/Dockerfile
+++ b/android-clang_9-armv8/Dockerfile
@@ -1,0 +1,22 @@
+FROM conanio/android-clang9
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV ANDROID_ABI=arm64-v8a \
+    CC=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android21-clang \
+    CXX=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android21-clang++ \
+    LD=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-ld \
+    AR=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-ar \
+    AS=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-as \
+    RANLIB=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-ranlib \
+    STRIP=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-strip \
+    ADDR2LINE=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-addr2line \
+    NM=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-nm \
+    OBJCOPY=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-objcopy \
+    OBJDUMP=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-objdump \
+    READELF=$STANDALONE_TOOLCHAIN/bin/aarch64-linux-android-readelf
+
+RUN conan profile update settings.arch=armv8 default \
+    && conan profile update settings.os=Android default \
+    && conan profile update settings.os.api_level=21 default \
+    && conan profile update settings.compiler.libcxx=libc++ default

--- a/android-clang_9-armv8/build.sh
+++ b/android-clang_9-armv8/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker build --no-cache -t conanio/android-clang9-armv8 .

--- a/android-clang_9-armv8/run.sh
+++ b/android-clang_9-armv8/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker run --rm -v ~/.conan/data:/home/conan/.conan/data -it conanio/android-clang9-armv8 /bin/bash

--- a/android-clang_9-x86/.dockerignore
+++ b/android-clang_9-x86/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/android-clang_9-x86/Dockerfile
+++ b/android-clang_9-x86/Dockerfile
@@ -1,0 +1,23 @@
+FROM conanio/android-clang9
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV ANDROID_ABI=x86 \
+    ANDROID_PLATFORM=android-16 \
+    CC=$STANDALONE_TOOLCHAIN/bin/i686-linux-android16-clang \
+    CXX=$STANDALONE_TOOLCHAIN/bin/i686-linux-android16-clang++ \
+    LD=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-ld \
+    AR=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-ar \
+    AS=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-as \
+    RANLIB=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-ranlib \
+    STRIP=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-strip \
+    ADDR2LINE=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-addr2line \
+    NM=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-nm \
+    OBJCOPY=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-objcopy \
+    OBJDUMP=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-objdump \
+    READELF=$STANDALONE_TOOLCHAIN/bin/i686-linux-android-readelf
+
+RUN conan profile update settings.arch=x86 default \
+    && conan profile update settings.os=Android default \
+    && conan profile update settings.os.api_level=16 default \
+    && conan profile update settings.compiler.libcxx=libc++ default

--- a/android-clang_9-x86/build.sh
+++ b/android-clang_9-x86/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker build --no-cache -t conanio/android-clang9-x86 .

--- a/android-clang_9-x86/run.sh
+++ b/android-clang_9-x86/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker run --rm -v ~/.conan/data:/home/conan/.conan/data -it conanio/android-clang9-x86 /bin/bash

--- a/android-clang_9/.dockerignore
+++ b/android-clang_9/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh

--- a/android-clang_9/Dockerfile
+++ b/android-clang_9/Dockerfile
@@ -1,0 +1,48 @@
+FROM conanio/gcc8
+
+ARG ANDROID_NDK_VERSION=r21
+ARG ANDROID_NDK=/android-ndk-${ANDROID_NDK_VERSION}
+ARG STANDALONE_TOOLCHAIN=/android-ndk-${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/linux-x86_64
+
+ENV ANDROID_NDK=$ANDROID_NDK \
+    ANDROID_NDK_HOME=$ANDROID_NDK \
+    STANDALONE_TOOLCHAIN=$STANDALONE_TOOLCHAIN \
+    ANDROID_STL=c++_shared \
+    ANDROID_ABI=x86_64 \
+    ANDROID_PLATFORM=android-21 \
+    ANDROID_TOOLCHAIN=clang \
+    CC=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android21-clang \
+    CXX=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android21-clang++ \
+    LD=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-ld \
+    AR=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-ar \
+    AS=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-as \
+    RANLIB=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-ranlib \
+    STRIP=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-strip \
+    ADDR2LINE=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-addr2line \
+    NM=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-nm \
+    OBJCOPY=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-objcopy \
+    OBJDUMP=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-objdump \
+    READELF=$STANDALONE_TOOLCHAIN/bin/x86_64-linux-android-readelf \
+    SYSROOT=$STANDALONE_TOOLCHAIN/sysroot \
+    CONAN_CMAKE_FIND_ROOT_PATH=$STANDALONE_TOOLCHAIN/sysroot \
+    CONAN_CMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+    CONAN_CMAKE_PROGRAM=/cmake-wrapper \
+    CMAKE_FIND_ROOT_PATH_MODE_PROGRAM=BOTH \
+    CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
+    CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+    CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+    PATH=$PATH:$STANDALONE_TOOLCHAIN/bin
+
+COPY cmake-wrapper /cmake-wrapper
+
+RUN sudo apt-get update \
+    && sudo apt-get -qq install -y --no-install-recommends unzip \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && sudo curl -s https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip -O \
+    && sudo unzip -qq android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip -d / \
+    && sudo rm -f android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip \
+    && sudo chmod +x /cmake-wrapper \
+    && conan profile new default --detect \
+    && conan profile update settings.os=Android default \
+    && conan profile update settings.os.api_level=21 default \
+    && conan profile update settings.compiler.libcxx=libc++ default

--- a/android-clang_9/build.sh
+++ b/android-clang_9/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo docker build --no-cache -t conanio/android-clang9 .

--- a/android-clang_9/cmake-wrapper
+++ b/android-clang_9/cmake-wrapper
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ALL_ARGS=$@
+
+BUILD=no
+for i in "$@":
+do
+  case $i in
+    --build)
+    BUILD=yes
+    ;;
+    *)
+    ;;
+  esac
+done
+
+# https://gitlab.kitware.com/cmake/cmake/issues/18739 Android: NDK r19 support
+# https://github.com/conan-io/conan/issues/2402 Android and CONAN_LIBCXX do not play well together
+# https://github.com/conan-io/conan/issues/4537 Pass ANDROID_ABI & ANDROID_NDK variables to cmake
+# https://github.com/conan-io/conan/issues/4629 set(CMAKE_FIND_ROOT_PATH_MODE_* ONLY) when cross-compiling, for Android at least
+
+if [ $BUILD == "yes" ]; then
+  cmake "$@"
+else
+  cmake \
+      -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=$CMAKE_FIND_ROOT_PATH_MODE_PROGRAM \
+      -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=$CMAKE_FIND_ROOT_PATH_MODE_LIBRARY \
+      -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=$CMAKE_FIND_ROOT_PATH_MODE_INCLUDE \
+      -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=$CMAKE_FIND_ROOT_PATH_MODE_PACKAGE \
+      -DANDROID_STL=$ANDROID_STL \
+      -DANDROID_NDK=$ANDROID_NDK \
+      -DANDROID_ABI=$ANDROID_ABI \
+      -DANDROID_PLATFORM=$ANDROID_PLATFORM \
+      -DANDROID_TOOLCHAIN=$ANDROID_TOOLCHAIN \
+      "$@"
+fi
+

--- a/android-clang_9/run.sh
+++ b/android-clang_9/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker run --rm -v ~/.conan/data:/home/conan/.conan/data -it conanio/android-clang9 /bin/bash


### PR DESCRIPTION
Adds clang 9 for android from NDK 21 as requested in #216.

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
