### PR TITLE
Replace eoan by Bionic

### DIFF
--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:eoan
+FROM i386/ubuntu:bionic
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -14,35 +14,35 @@ ENV LLVM_VERSION=9.0 \
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.* \
-       wget=1.* \
-       git=1:2.* \
-       g++-multilib=4:9.* \
-       clang-9=1:9* \
-       make=4.2.* \
-       libc6-dev=2.* \
-       libgmp-dev=2:6.* \
-       libmpfr-dev=4.* \
-       libmpc-dev=1.* \
-       nasm=2.* \
-       dh-autoreconf=19 \
-       libffi-dev=3.* \
-       libssl-dev=1* \
-       ninja-build=1.* \
-       libc++-dev=1:9.* \
-       libc++abi-dev=1:9.* \
-       pkg-config=0.* \
-       subversion=1.* \
-       zlib1g-dev=1:1.* \
-       libbz2-dev=1.* \
-       libsqlite3-dev=3.* \
-       libreadline-dev=8.* \
-       xz-utils=5.* \
-       curl=7.* \
-       libncurses5-dev=6.* \
-       libncursesw5-dev=6.* \
-       liblzma-dev=5.* \
-       gnupg=2.* \
+       sudo \
+       wget \
+       git \
+       g++-multilib \
+       clang-9 \
+       make \
+       libc6-dev \
+       libgmp-dev \
+       libmpfr-dev \
+       libmpc-dev \
+       nasm \
+       dh-autoreconf \
+       libffi-dev \
+       libssl-dev \
+       ninja-build \
+       libc++-dev \
+       libc++abi-dev \
+       pkg-config \
+       subversion \
+       zlib1g-dev \
+       libbz2-dev \
+       libsqlite3-dev \
+       libreadline-dev \
+       xz-utils \
+       curl \
+       libncurses5-dev \
+       libncursesw5-dev \
+       liblzma-dev \
+       gnupg \
        ca-certificates \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100 \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:bionic
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -13,38 +13,38 @@ ENV LLVM_VERSION=9.0 \
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-       sudo=1.* \
-       wget=1.* \
-       git=1:2.* \
-       g++-multilib=4:9.* \
-       clang-9=1:9* \
-       make=4.* \
-       libc6-dev-i386=2.* \
-       libgmp-dev=2:6.* \
-       libmpfr-dev=4.* \
-       libmpc-dev=1.* \
-       nasm=2.* \
-       dh-autoreconf=19 \
-       libffi-dev=3.* \
-       libssl-dev=1* \
-       ninja-build=1.* \
-       libc++-dev=1:9.* \
-       libc++abi-dev=1:9.* \
-       pkg-config=0.* \
-       subversion=1.* \
-       zlib1g-dev=1:1.* \
-       libbz2-dev=1.* \
-       libsqlite3-dev=3.* \
-       libreadline-dev=8.* \
-       xz-utils=5.* \
-       curl=7.* \
-       libncurses5-dev=6.* \
-       libncursesw5-dev=6.* \
-       liblzma-dev=5.* \
-       gnupg=2.* \
+       sudo \
+       wget \
+       git \
+       #g++-multilib=4:9.* \
+       clang-9 \
+       make \
+       libc6-dev-i386 \
+       libgmp-dev \
+       libmpfr-dev \
+       libmpc-dev \
+       nasm \
+       dh-autoreconf \
+       libffi-dev \
+       libssl-dev \
+       ninja-build \
+       libc++-dev \
+       libc++abi-dev \
+       pkg-config \
+       subversion \
+       zlib1g-dev \
+       libbz2-dev \
+       libsqlite3-dev \
+       libreadline-dev \
+       xz-utils \
+       curl \
+       libncurses5-dev \
+       libncursesw5-dev \
+       liblzma-dev \
+       gnupg \
        ca-certificates \
-       # libc++abi-dev:i386=1:9.* \
-       # libc++-dev:i386=1:9.* \
+       libc++abi-dev:i386 \
+       libc++-dev:i386 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-9 100 \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:eoan
+FROM i386/ubuntu:bionic
 ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -11,33 +11,33 @@ ENV CONAN_ENV_ARCH=x86 \
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.* \
-       binutils=2.* \
-       wget=1.* \
-       git=1:2.* \
-       libc6-dev=2.* \
-       linux-libc-dev=5.* \
+       sudo \
+       binutils \
+       wget \
+       git \
+       libc6-dev \
+       linux-libc-dev \
        g++-9 \
-       libgmp-dev=2:6.* \
-       libmpfr-dev=4.* \
-       libmpc-dev=1.* \
-       libc6-dev=2.* \
-       nasm=2.* \
-       dh-autoreconf=19 \
-       ninja-build=1.* \
-       libffi-dev=3.* \
-       libssl-dev=1.* \
-       pkg-config=0.* \
-       subversion=1.* \
-       zlib1g-dev=1:1.* \
-       libbz2-dev=1.* \
-       libsqlite3-dev=3.* \
-       libreadline-dev=8.* \
-       xz-utils=5.* \
-       curl=7.* \
-       libncurses5-dev=6.* \
-       libncursesw5-dev=6.* \
-       liblzma-dev=5.* \
+       libgmp-dev \
+       libmpfr-dev \
+       libmpc-dev \
+       libc6-dev \
+       nasm \
+       dh-autoreconf \
+       ninja-build \
+       libffi-dev \
+       libssl-dev \
+       pkg-config \
+       subversion \
+       zlib1g-dev \
+       libbz2-dev \
+       libsqlite3-dev \
+       libreadline-dev \
+       xz-utils \
+       curl \
+       libncurses5-dev \
+       libncursesw5-dev \
+       liblzma-dev \
        ca-certificates \
        autoconf-archive \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100 \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:bionic
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -10,33 +10,33 @@ ENV PYENV_ROOT=/opt/pyenv \
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       sudo=1.* \
-       binutils=2.* \
-       wget=1.* \
-       git=1:2.* \
-       libc6-dev-i386=2.* \
-       libc6-dev=2.* \
-       linux-libc-dev:i386=5* \
+       sudo \
+       binutils \
+       wget \
+       git \
+       libc6-dev-i386 \
+       libc6-dev \
+       linux-libc-dev:i386 \
        g++-9-multilib \
-       libgmp-dev=2:6.* \
-       libmpfr-dev=4.* \
-       libmpc-dev=1.* \
-       nasm=2.* \
-       dh-autoreconf=19 \
-       ninja-build=1.* \
-       libffi-dev=3.* \
-       libssl-dev=1.* \
-       pkg-config=0.* \
-       subversion=1.* \
-       zlib1g-dev=1:1.* \
-       libbz2-dev=1.* \
-       libsqlite3-dev=3.* \
-       libreadline-dev=8.* \
-       xz-utils=5.* \
-       curl=7.* \
-       libncurses5-dev=6.* \
-       libncursesw5-dev=6.* \
-       liblzma-dev=5.* \
+       libgmp-dev \
+       libmpfr-dev \
+       libmpc-dev \
+       nasm \
+       dh-autoreconf \
+       ninja-build \
+       libffi-dev \
+       libssl-dev \
+       pkg-config \
+       subversion \
+       zlib1g-dev \
+       libbz2-dev \
+       libsqlite3-dev \
+       libreadline-dev \
+       xz-utils \
+       curl \
+       libncurses5-dev \
+       libncursesw5-dev \
+       liblzma-dev \
        ca-certificates \
        autoconf-archive \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100 \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -9,6 +9,10 @@ ENV PYENV_ROOT=/opt/pyenv \
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends gnupg \
+    && printf "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main\n" >> /etc/apt/sources.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F \
+    && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
        sudo \
        binutils \


### PR DESCRIPTION
Ubuntu Eoan (19.10) reached EOL and archives.ubuntu.com won't work. Another option is adding old-releases.ubuntu.com, but it didn't work for me.

Ubuntu Bionic (18.04) is LTS and will be supported until 2024. As it's older than 19.04, the glibc version is compatible. 

Ubuntu only provides a single package version, so if a package becomes outdated, won't be possible to install the old version, thus specific version or ranged version is useless.

fixes https://github.com/conan-io/conan-docker-tools/issues/233 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
