### PR TITLE
Eating Our Own Ice Cream: Use Conan's CMake recipe

### DIFF
--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -78,7 +78,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION_FULL} \
+    && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
@@ -87,8 +87,28 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+   && cd conan_packages \
+   # Temporary dependencies for (potential) boostrapping purposes 
+   && apt-get -qq update \
+   && apt-get -qq install -y --no-install-recommends cmake \
+   # Install Packages which we want to deploy
+   # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+   && cd cmake/licenses \
+   && mkdir cmake \ 
+   && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -3,14 +3,15 @@ FROM ubuntu:bionic AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=10 \
+    CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
     CMAKE_CXX_COMPILER=clang++ \
     PYENV_ROOT=/opt/pyenv \
     PYTHON_VERSION=3.8.2 \
-    PATH=/opt/pyenv/shims:${PATH} \
-    CMAKE_VERSION_FULL=3.18.5
+    PATH=/opt/pyenv/shims:${PATH}
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
@@ -97,7 +98,7 @@ RUN mkdir conan_packages \
    && apt-get -qq install -y --no-install-recommends cmake \
    # Install Packages which we want to deploy
    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+   && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
    && cd cmake/licenses \
    && mkdir cmake \ 
    && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -10,7 +10,7 @@ ENV LLVM_VERSION=10 \
     PYENV_ROOT=/opt/pyenv \
     PYTHON_VERSION=3.8.2 \
     PATH=/opt/pyenv/shims:${PATH} \
-    CMAKE_VERSION_FULL=3.18.2
+    CMAKE_VERSION_FULL=3.18.4
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -10,7 +10,7 @@ ENV LLVM_VERSION=10 \
     PYENV_ROOT=/opt/pyenv \
     PYTHON_VERSION=3.8.2 \
     PATH=/opt/pyenv/shims:${PATH} \
-    CMAKE_VERSION_FULL=3.18.4
+    CMAKE_VERSION_FULL=3.18.5
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \

--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=11 \
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -98,7 +99,7 @@ RUN mkdir conan_packages \
    && apt-get -qq install -y --no-install-recommends cmake \
    # Install Packages which we want to deploy
    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+   && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
    && cd cmake/licenses \
    && mkdir cmake \ 
    && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=11 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -79,7 +79,7 @@ RUN dpkg --add-architecture i386 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION_FULL} \
+    && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
@@ -88,8 +88,24 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+   && cd conan_packages \
+   # Temporary dependencies for (potential) boostrapping purposes 
+   && apt-get -qq update \
+   && apt-get -qq install -y --no-install-recommends cmake \
+   # Install Packages which we want to deploy
+   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy 
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -97,7 +97,11 @@ RUN mkdir conan_packages \
    && apt-get -qq update \
    && apt-get -qq install -y --no-install-recommends cmake \
    # Install Packages which we want to deploy
-   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy 
+   # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+   && cd cmake/licenses \
+   && mkdir cmake \ 
+   && ls | grep -v cmake | xargs mv -t cmake
 
 
 FROM basics AS final_image 

--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=11 \
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM ubuntu:zesty AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -58,15 +58,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -92,8 +83,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.8 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=3.8 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -99,7 +100,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_3.8/Dockerfile
+++ b/clang_3.8/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.8 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:artful
+FROM i386/ubuntu:artful AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -59,14 +59,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -92,8 +84,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.9 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.9 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_3.9-x86/Dockerfile
+++ b/clang_3.9-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=3.9 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -100,7 +101,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=3.9 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -104,7 +105,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -61,15 +61,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -97,8 +88,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.9 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.9 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=4.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:artful
+FROM i386/ubuntu:artful AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -59,14 +59,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -92,8 +84,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=4.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_4.0-x86/Dockerfile
+++ b/clang_4.0-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=4.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -100,7 +101,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -60,15 +60,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -96,8 +87,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=4.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=4.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=4.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -103,7 +104,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:artful
+FROM i386/ubuntu:artful AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -55,14 +55,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -88,8 +80,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=5.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=5.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -96,7 +97,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_5.0-x86/Dockerfile
+++ b/clang_5.0-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=5.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=5.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -99,7 +100,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=5.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -56,15 +56,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-5.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -92,8 +83,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=5.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=6.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -94,7 +95,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:bionic
+FROM i386/ubuntu:bionic AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -53,14 +53,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -86,8 +78,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=6.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_6.0-x86/Dockerfile
+++ b/clang_6.0-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=6.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=6.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:bionic AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=6.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -54,15 +54,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-6.0 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -90,8 +81,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=6.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -97,7 +98,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:cosmic
+FROM i386/ubuntu:cosmic AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -55,14 +55,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -88,8 +80,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=7.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=7.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_7-x86/Dockerfile
+++ b/clang_7-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=7.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -96,7 +97,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=7.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -99,7 +100,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:cosmic AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=7.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:cosmic
+FROM ubuntu:cosmic AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -56,15 +56,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -92,8 +83,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=7.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:disco
+FROM i386/ubuntu:disco AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -55,14 +55,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -88,8 +80,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=8.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -96,7 +97,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=8.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_8-x86/Dockerfile
+++ b/clang_8-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=8.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=8.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=8.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -102,7 +103,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:disco AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=8.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:disco AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -59,15 +59,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -95,8 +86,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=9.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=9.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=9.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -96,7 +97,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_9-x86/Dockerfile
+++ b/clang_9-x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:eoan
+FROM i386/ubuntu:eoan AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
@@ -55,14 +55,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -88,8 +80,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:eoan AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -56,15 +56,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -92,8 +83,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 ENV LLVM_VERSION=9.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \
@@ -99,7 +100,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=9.0 \
     CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:eoan AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=9.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=clang \
     CXX=clang++ \
     CMAKE_C_COMPILER=clang \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2
+    CMAKE_VERSION_FULL=3.18.4
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \

--- a/conan_test_azure/Dockerfile
+++ b/conan_test_azure/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4
+    CMAKE_VERSION_FULL=3.18.5
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \

--- a/gcc_10/Dockerfile
+++ b/gcc_10/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV GCC_VERSION=10 \
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CC=/usr/bin/gcc \
     CXX=/usr/bin/g++ \
     CMAKE_C_COMPILER=gcc \

--- a/gcc_10/Dockerfile
+++ b/gcc_10/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV GCC_VERSION=10 \
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CC=/usr/bin/gcc \
     CXX=/usr/bin/g++ \
     CMAKE_C_COMPILER=gcc \
@@ -92,7 +93,7 @@ RUN mkdir conan_packages \
     && apt-get -qq install -y --no-install-recommends cmake \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_10/Dockerfile
+++ b/gcc_10/Dockerfile
@@ -1,44 +1,54 @@
-FROM ubuntu:focal
+FROM ubuntu:focal AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV GCC_VERSION=10 \
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CC=/usr/bin/gcc \
     CXX=/usr/bin/g++ \
+    CMAKE_C_COMPILER=gcc \
+    CMAKE_CXX_COMPILER=g++ \
     PYENV_ROOT=/opt/pyenv \
     PYTHON_VERSION=3.7.5 \
     PATH=/opt/pyenv/shims:${PATH} \
     DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
+    # Install basics
     && apt-get -qq install -y --no-install-recommends \
        sudo \
-       binutils \
        wget \
        git \
+       subversion \
+       make \
+       ca-certificates \
+       dh-autoreconf \
+    # Install compiler toolset
+    && apt-get -qq install -y --no-install-recommends \
+       binutils \
        libc6-dev \
        g++-${GCC_VERSION} \
-       libgmp-dev \
-       libmpfr-dev \
-       libmpc-dev \
-       nasm \
-       dh-autoreconf \
-       ninja-build \
+    # Install dependencies of Python
+    && apt-get -qq install -y --no-install-recommends \
+       libreadline-dev \
+       libsqlite3-dev \
        libffi-dev \
        libssl-dev \
-       pkg-config \
-       subversion \
        zlib1g-dev \
        libbz2-dev \
-       libsqlite3-dev \
-       libreadline-dev \
        xz-utils \
        curl \
        libncurses5-dev \
        libncursesw5-dev \
        liblzma-dev \
-       ca-certificates \
+    # Install stuff for compatiblity, which we don't want to install in new images anymore
+    && apt-get -qq install -y --no-install-recommends \
+       nasm \
+       ninja-build \
+       pkg-config \
+       libgmp-dev \
+       libmpfr-dev \
+       libmpc-dev \
        autoconf-archive \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} 100 \
@@ -64,7 +74,7 @@ RUN apt-get -qq update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
     && pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION_FULL} \
+    && pip install -q --no-cache-dir conan conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
@@ -72,8 +82,28 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends cmake \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:precise
+FROM ubuntu:precise AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -36,15 +36,6 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz http://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz -C /tmp \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-       --exclude=share/vim \
-    && cp -fR /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -73,23 +64,19 @@ RUN apt-get -qq update \
 
 FROM basics AS building_layer 
 
-RUN mkdir conan_packages \
+COPY ./conanfile.py conanfile.py
+
+RUN mkdir -p conan_packages/cmake \
     && cd conan_packages \
-    # Temporary dependencies for (potential) boostrapping purposes 
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
-    # Install Packages which we want to deploy
-    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
-    && cd cmake/licenses \
-    && mkdir cmake \ 
-    && ls | grep -v cmake | xargs mv -t cmake
+    # CMake can't be built with GCC 4.6, so let's download official binaries
+    && wget -q --no-check-certificate -O /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz http://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && tar -xzf /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz -C /tmp \
+    --exclude=bin/cmake-gui \
+    --exclude=doc/cmake \
+    --exclude=share/cmake-${CMAKE_VERSION_FULL}/Help \
+    --exclude=share/vim \
+    && cp -fR /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /conan_packages/cmake/ \
+    && rm -rf /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64*
 
 
 FROM basics AS final_image 

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -64,8 +64,6 @@ RUN apt-get -qq update \
 
 FROM basics AS building_layer 
 
-COPY ./conanfile.py conanfile.py
-
 RUN mkdir -p conan_packages/cmake \
     && cd conan_packages \
     # CMake can't be built with GCC 4.6, so let's download official binaries

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:precise
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -70,8 +70,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:precise AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -1,10 +1,10 @@
-FROM i386/ubuntu:trusty
+FROM i386/ubuntu:trusty AS basics
 ENTRYPOINT ["linux32", "--"]
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -38,14 +38,6 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -72,8 +64,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["linux32", "--"]
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -81,7 +82,7 @@ RUN mkdir conan_packages \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
     # To avoid GLIBC/CXX compatibility issues, we have to (re)build the package
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -69,7 +69,7 @@ FROM basics AS building_layer
 
 RUN mkdir conan_packages \
     && cd conan_packages \
-    # Temporary dependencies for (potential) boostrapping purposes 
+    # Temporary dependencies for boostrapping purposes
     && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
     && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
     && cd cmake-${CMAKE_VERSION_FULL} \
@@ -80,7 +80,8 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    # To avoid GLIBC/CXX compatibility issues, we have to (re)build the package
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:trusty AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -38,15 +38,6 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -78,7 +69,7 @@ FROM basics AS building_layer
 
 RUN mkdir conan_packages \
     && cd conan_packages \
-    # Temporary dependencies for (potential) boostrapping purposes 
+    # Temporary dependencies for boostrapping purposes
     && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
     && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
     && cd cmake-${CMAKE_VERSION_FULL} \
@@ -89,7 +80,8 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    # To avoid GLIBC/CXX compatibility issues, we have to (re)build the package
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -73,8 +73,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:trusty
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:trusty AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -81,7 +82,7 @@ RUN mkdir conan_packages \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
     # To avoid GLIBC/CXX compatibility issues, we have to (re)build the package
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:wily AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:wily
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -75,6 +75,11 @@ ENV CC=arm-linux-gnueabi-gcc-4.9 \
 
 FROM basics AS building_layer 
 
+ENV CXX=/usr/bin/g++-4.9 \
+    CC=/usr/bin/gcc-4.9 \
+    CMAKE_C_COMPILER=gcc-4.9 \
+    CMAKE_CXX_COMPILER=g++-4.9
+
 RUN mkdir conan_packages \
     && cd conan_packages \
     # Temporary dependencies for (potential) boostrapping purposes 

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:wily
+FROM ubuntu:wily AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -36,15 +36,6 @@ RUN apt-get -qq update \
     autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -81,8 +72,34 @@ ENV CC=arm-linux-gnueabi-gcc-4.9 \
     LD=arm-linux-gnueabi-ld \
     FC=arm-linux-gnueabi-gfortran-4.9
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 
@@ -93,7 +94,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:wily
+FROM ubuntu:wily AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -38,15 +38,6 @@ RUN dpkg --add-architecture armhf \
     autoconf-archive \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -83,8 +74,34 @@ ENV CC=arm-linux-gnueabihf-gcc-4.9 \
     LD=arm-linux-gnueabihf-ld \
     FC=arm-linux-gnueabihf-gfortran-4.9
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 
@@ -95,7 +96,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:wily AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:wily
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -77,6 +77,11 @@ ENV CC=arm-linux-gnueabihf-gcc-4.9 \
 
 FROM basics AS building_layer 
 
+ENV CXX=/usr/bin/g++-4.9 \
+    CC=/usr/bin/gcc-4.9 \
+    CMAKE_C_COMPILER=gcc-4.9 \
+    CMAKE_CXX_COMPILER=g++-4.9
+
 RUN mkdir conan_packages \
     && cd conan_packages \
     # Temporary dependencies for (potential) boostrapping purposes 

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["linux32", "--"]
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -87,7 +88,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -1,10 +1,10 @@
-FROM i386/ubuntu:trusty
+FROM i386/ubuntu:trusty AS basics
 ENTRYPOINT ["linux32", "--"]
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -45,14 +45,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -79,8 +71,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -83,8 +83,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:trusty
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -45,16 +45,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.9 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.9 100 \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -89,7 +90,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:trusty AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:trusty
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -1,10 +1,10 @@
-FROM i386/ubuntu:xenial
+FROM i386/ubuntu:xenial AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -41,14 +41,6 @@ RUN apt-get -qq update \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-       && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-       && cd cmake-${CMAKE_VERSION_FULL} \
-       && ./bootstrap > /dev/null \
-       && make -s -j`nproc` \
-       && make -s install > /dev/null \
-       && cd - \
-       && rm -rf cmake-* \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \
@@ -74,8 +66,34 @@ RUN apt-get -qq update \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
        && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/i
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_5-x86/Dockerfile
+++ b/gcc_5-x86/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -82,7 +83,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:wily
+FROM ubuntu:wily AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -39,15 +39,6 @@ RUN dpkg --add-architecture i386 \
     ca-certificates \
     autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -73,8 +64,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -80,7 +81,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:wily AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:wily AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -128,7 +129,7 @@ RUN mkdir conan_packages \
    && rm -rf cmake-* \
    # Install Packages which we want to deploy
    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+   && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
    && cd cmake/licenses \
    && mkdir cmake \ 
    && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -87,14 +87,6 @@ RUN dpkg --add-architecture i386 \
        autoconf-archive \
     && ln -s /usr/bin/g++-5 /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.14/Help \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -120,8 +112,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+   && cd conan_packages \
+   # Temporary dependencies for (potential) boostrapping purposes 
+   && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+   && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+   && cd cmake-${CMAKE_VERSION_FULL} \
+   && ./bootstrap > /dev/null \
+   && make -s -j`nproc` \
+   && make -s install > /dev/null \
+   && cd - \
+   && rm -rf cmake-* \
+   # Install Packages which we want to deploy
+   # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+   && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+   && cd cmake/licenses \
+   && mkdir cmake \ 
+   && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -41,15 +41,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-       && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-       && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-       && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \
@@ -75,8 +66,34 @@ RUN dpkg --add-architecture i386 \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
        && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -82,7 +83,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -84,7 +85,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -41,15 +41,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
        && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-          --exclude=bin/cmake-gui \
-          --exclude=doc/cmake \
-          --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-       && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-       && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-       && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
        && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
        && chmod +x /usr/local/bin/jfrog \
        && groupadd 1001 -g 1001 \
@@ -77,8 +68,34 @@ RUN dpkg --add-architecture i386 \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
        && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:xenial AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -91,7 +92,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -1,10 +1,10 @@
-FROM i386/ubuntu:artful
+FROM i386/ubuntu:artful AS basics
 ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -50,14 +50,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -83,8 +75,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_6-x86/Dockerfile
+++ b/gcc_6-x86/Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["linux32", "--"]  # https://github.com/conan-io/conan-docker-tools/i
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:yakkety AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:yakkety
+FROM ubuntu:yakkety AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -43,15 +43,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -77,8 +68,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:yakkety AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -84,7 +85,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -84,7 +85,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM ubuntu:zesty AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -43,15 +43,6 @@ RUN dpkg --add-architecture i386 \
        ca-certificates \
        autoconf-archive \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -77,8 +68,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:zesty AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:zesty AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -48,15 +48,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -82,8 +73,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6.4/Dockerfile
+++ b/gcc_6.4/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -89,7 +90,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -92,7 +93,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -49,15 +49,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -85,8 +76,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:artful
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -91,7 +92,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -1,10 +1,10 @@
-FROM i386/ubuntu:artful
+FROM i386/ubuntu:artful AS basics
 ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -50,14 +50,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -83,8 +75,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_7-x86/Dockerfile
+++ b/gcc_7-x86/Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/is
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CC=/usr/bin/gcc \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -46,15 +46,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -80,8 +71,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CC=/usr/bin/gcc \

--- a/gcc_7.2/Dockerfile
+++ b/gcc_7.2/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CC=/usr/bin/gcc \
@@ -87,7 +88,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -47,15 +47,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -83,8 +74,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -90,7 +91,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:artful AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -89,7 +90,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -1,10 +1,10 @@
-FROM i386/ubuntu:bionic
+FROM i386/ubuntu:bionic AS basics
 ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+    CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -48,14 +48,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -81,8 +73,34 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_8-x86/Dockerfile
+++ b/gcc_8-x86/Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/is
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:bionic AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.4 \
+    CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
     CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -90,7 +91,7 @@ RUN mkdir conan_packages \
     && rm -rf cmake-* \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -47,15 +47,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -83,8 +74,34 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
+    && cd cmake-${CMAKE_VERSION_FULL} \
+    && ./bootstrap > /dev/null \
+    && make -s -j`nproc` \
+    && make -s install > /dev/null \
+    && cd - \
+    && rm -rf cmake-* \
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -82,7 +82,11 @@ RUN mkdir conan_packages \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends cmake \
     # Install Packages which we want to deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy 
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
 
 
 FROM basics AS final_image 

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -4,6 +4,7 @@ ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/is
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -84,7 +85,7 @@ RUN mkdir conan_packages \
     && apt-get -qq install -y --no-install-recommends cmake \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -1,10 +1,9 @@
-FROM i386/ubuntu:eoan
+FROM i386/ubuntu:eoan AS basics
 ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/issues/36
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_FULL=3.18.4 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -50,14 +49,6 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}.tar.gz \
-    && cd cmake-${CMAKE_VERSION_FULL} \
-    && ./bootstrap > /dev/null \
-    && make -s -j`nproc` \
-    && make -s install > /dev/null \
-    && cd - \
-    && rm -rf cmake-* \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \
@@ -83,8 +74,23 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Temporary dependencies for (potential) boostrapping purposes 
+    && apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends cmake \
+    # Install Packages which we want to deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy 
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
 FROM basics AS building_layer 
 
 RUN mkdir conan_packages \

--- a/gcc_9-x86/Dockerfile
+++ b/gcc_9-x86/Dockerfile
@@ -3,7 +3,7 @@ ENTRYPOINT ["linux32", "--"] # https://github.com/conan-io/conan-docker-tools/is
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_FULL=3.18.4 \
+ENV CMAKE_VERSION_FULL=3.18.5 \
     CONAN_ENV_ARCH=x86 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:eoan AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_FULL=3.18.4 \
+ENV CMAKE_VERSION_FULL=3.18.5 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:eoan AS basics
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV CMAKE_VERSION_FULL=3.18.5 \
+    CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -85,7 +86,7 @@ RUN mkdir conan_packages \
     && apt-get -qq install -y --no-install-recommends cmake \
     # Install Packages which we want to deploy
     # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && CONAN_REVISIONS_ENABLED=1 conan install cmake/${CMAKE_VERSION_FULL}@#${CMAKE_RREV} --build missing -g deploy \
     && cd cmake/licenses \
     && mkdir cmake \ 
     && ls | grep -v cmake | xargs mv -t cmake

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -80,11 +80,15 @@ FROM basics AS building_layer
 
 RUN mkdir conan_packages \
     && cd conan_packages \
-    # Install dependencies for (potential) boostrapping purposes 
+    # Temporary dependencies for (potential) boostrapping purposes 
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends cmake \
-    # Install Packages we want to deploy then
-    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy 
+    # Install Packages which we want to deploy
+    # Install CMake + move license files to specific licenses/cmake subdirectory for deploy
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy \
+    && cd cmake/licenses \
+    && mkdir cmake \ 
+    && ls | grep -v cmake | xargs mv -t cmake
 
 
 FROM basics AS final_image 

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:eoan
+FROM ubuntu:eoan AS basics
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
-    CMAKE_VERSION_FULL=3.18.2 \
+ENV CMAKE_VERSION_FULL=3.18.4 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
@@ -49,15 +48,6 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-${CMAKE_VERSION_MAJOR_MINOR}/Help \
-       --exclude=share/vim \
-    && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
-    && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
@@ -85,8 +75,24 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
 
+
+FROM basics AS building_layer 
+
+RUN mkdir conan_packages \
+    && cd conan_packages \
+    # Install dependencies for (potential) boostrapping purposes 
+    && apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends cmake \
+    # Install Packages we want to deploy then
+    && conan install cmake/${CMAKE_VERSION_FULL}@ --build missing -g deploy 
+
+
+FROM basics AS final_image 
+
 USER conan
 WORKDIR /home/conan
+
+COPY --from=building_layer /conan_packages/cmake/ /usr/
 
 RUN mkdir -p /home/conan/.conan \
     && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \

--- a/update_cmake.py
+++ b/update_cmake.py
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     for old, new in [
         ("CMAKE_VERSION_MAJOR_MINOR=3.17", "CMAKE_VERSION_MAJOR_MINOR=3.18"),
         ("CMAKE_VERSION_FULL=3.18.4", "CMAKE_VERSION_FULL=3.18.5"),
+        ("CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226", "CMAKE_RREV=fabfeac4dd61c45dc0a0451408769226"),
     ]:
 
         for root, _, filenames in os.walk("./"):

--- a/update_cmake.py
+++ b/update_cmake.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
 
     for old, new in [
         ("CMAKE_VERSION_MAJOR_MINOR=3.17", "CMAKE_VERSION_MAJOR_MINOR=3.18"),
-        ("CMAKE_VERSION_FULL=3.17.0", "CMAKE_VERSION_FULL=3.18.2"),
+        ("CMAKE_VERSION_FULL=3.18.2", "CMAKE_VERSION_FULL=3.18.4"),
     ]:
 
         for root, _, filenames in os.walk("./"):

--- a/update_cmake.py
+++ b/update_cmake.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
 
     for old, new in [
         ("CMAKE_VERSION_MAJOR_MINOR=3.17", "CMAKE_VERSION_MAJOR_MINOR=3.18"),
-        ("CMAKE_VERSION_FULL=3.18.2", "CMAKE_VERSION_FULL=3.18.4"),
+        ("CMAKE_VERSION_FULL=3.18.4", "CMAKE_VERSION_FULL=3.18.5"),
     ]:
 
         for root, _, filenames in os.walk("./"):


### PR DESCRIPTION
Changelog: Feature: Use a Conan build of CMake for our build images

https://en.wikipedia.org/wiki/Eating_your_own_dog_food#Alternative_terms 

Let's try this first with CMake and get some experience. Later we can 
  * move more dependencies like this.
  * Particular the compilers itself once GCC and LLVM recipes are ready for that. This would makes us vastly more independent of specific Ubuntu versions.
  * @madebr is working on a Python recipe, maybe this will work well too ✌️ 

_____________________

- [x] Requires https://github.com/conan-io/conan-center-index/pull/4147

_____________________

Some explanations:
  * GCC 4.6 is too old to build CMake. Hence we download the official binaries von Kitware. This works because this image is 64 bit and there is no GCC 4.6 32 bit container.  Kitware does not provide 32 bit binaries. (And these old containers should probably be removed anyways, https://github.com/conan-io/conan-docker-tools/issues/240)
  * Our CMake recipe is building CMake with CMake
  * Bootstraping of CMake works via `make`
  * For most other compiler versions, except the newest, we do have 32 bit containers. Here, we can not use the official binaries, but rather we compile the source code and bootstrap a CMake build via `make`. 
  * Under regular circumstances, we already have Conan packages for CMake available which can be just downloaded. However, who knows what could happen, so these containers should be able to bootstrap. Only when the Conan remote offers no CMake packages to download, we build the Conan CMake recipe with the CMake binary we acquired previously
  * The final image only contains a CMake which was build via Conan (except the GCC 4.6 image)
  * In the future, we might want to add a bootstrap option directly to the CMake Conan recipe, but for now, this is fine
  * This also works good as a proof-of-concept and this workflow can be used eventually for the compilers, the Python runtime and probably other packages too. But let's see how this performs in practice with CMake as this is ready-to-go right now and much less complex than those other packages
