### PR TITLE
Install JFrog CLI for all CCI images

### DIFF
--- a/build.py
+++ b/build.py
@@ -291,6 +291,14 @@ class ConanDockerTools(object):
                 "arch_build=%s -s os_build=Linux --build" % (self.service, arch),
                 shell=True)
 
+        try:
+            subprocess.check_call(
+                "docker exec %s ls /usr/local/bin/jfrog" % self.service, shell=True)
+        except:
+            pass
+        else:
+            subprocess.check_call("docker exec %s jfrog --version" % self.service, shell=True)
+
     def test_jenkins(self):
         logging.info("Testing Jenkins Docker: running service %s." % self.service)
         output = subprocess.check_output("docker run --rm -t --name %s %s" % (self.service,

--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -26,9 +26,9 @@ RUN dpkg --add-architecture i386 \
        dh-autoreconf \
     # Install compiler toolset
     && apt-get install -y --no-install-recommends \
-       lsb-release \ 
+       lsb-release \
        software-properties-common \
-    && wget https://apt.llvm.org/llvm.sh \ 
+    && wget https://apt.llvm.org/llvm.sh \
     && chmod +x llvm.sh \
     && sudo ./llvm.sh ${LLVM_VERSION} \
     && rm llvm.sh \
@@ -60,6 +60,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -11,7 +11,7 @@ ENV LLVM_VERSION=11 \
     PYENV_ROOT=/opt/pyenv \
     PYTHON_VERSION=3.8.2 \
     PATH=/opt/pyenv/shims:${PATH}
-    
+
 
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
@@ -61,6 +61,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=3.9 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -70,6 +70,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=4.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -69,6 +69,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:artful
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=5.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -65,6 +65,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=6.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -63,6 +63,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:cosmic
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=7.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -65,6 +65,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:disco
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=8.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -68,6 +68,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:eoan
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 ENV LLVM_VERSION=9.0 \
-    CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+    CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     CC=clang \
     CXX=clang++ \
@@ -11,7 +11,7 @@ ENV LLVM_VERSION=9.0 \
     CMAKE_CXX_COMPILER=clang++ \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
-	
+
 COPY sources.list /etc/apt/sources.list
 
 RUN dpkg --add-architecture i386 \
@@ -65,6 +65,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_10/Dockerfile
+++ b/gcc_10/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -55,6 +55,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -50,6 +50,8 @@ RUN dpkg --add-architecture i386 \
        && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
        && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
        && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+       && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+       && chmod +x /usr/local/bin/jfrog \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \
        && groupadd 2000 -g 2000 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:artful
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -58,6 +58,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:artful
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -56,6 +56,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
@@ -56,6 +56,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -2,13 +2,13 @@ FROM ubuntu:eoan
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \ 
+ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH} \
     CXX=/usr/bin/g++ \
     CC=/usr/bin/gcc
-	
+
 COPY sources.list /etc/apt/sources.list
 
 RUN dpkg --add-architecture i386 \
@@ -58,6 +58,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \
     && groupadd 2000 -g 2000 \


### PR DESCRIPTION
As Conan Center Index is doing internal changes, JFrog CLI will be required.

I didn't add for x86 images because they are optional and not used by CCI.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
