### PR TITLE
Fix Conan Test bad imports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,10 @@ jobs:
       DOCKER_PASSWORD: $(DOCKER_PASSWORD)
   strategy:
     matrix:
+      Conan Tests:
+        BUILD_CONAN_TESTS: 1
+        BUILD_CONAN_TEST_AZURE: 1
+
       Conan Tests Agent:
         BUILD_CONAN_TEST_AGENT: 1
 
@@ -161,7 +165,3 @@ jobs:
 
       Conan Server:
         BUILD_CONAN_SERVER_IMAGE: 1
-
-      Conan Tests:
-        BUILD_CONAN_TESTS: 1
-        BUILD_CONAN_TEST_AZURE: 1

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -9,8 +9,13 @@ RUN sudo apt-get update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.5.7 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.9 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.1 \
-    && pyenv global 3.8.1 \
-    && python -m pip install --upgrade pip "virtualenv<20.0.0" PyGithub conan meson
+    && pyenv global 3.8.1
+
+RUN python -m pip install --upgrade pip
+RUN python -m pip install meson
+RUN python -m pip install "virtualenv<20.0.0"
+RUN python -m pip install PyGithub
+RUN python -m pip install conan
 
 USER conan
 WORKDIR /home/conan

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -7,29 +7,20 @@ RUN sudo apt-get update \
     && sudo add-apt-repository ppa:deadsnakes/ppa -y \
     && sudo apt-get update \
     && sudo apt-get -qq install -y --no-install-recommends \
-    python-software-properties \
-    python3.5 \
-    python3.6 \
-    python3.7 \
-    python3.8 \
-    python-setuptools \
-    python-dev \
-    python3.5-dev \
-    python3.6-dev \
-    python3.7-dev \
-    python3.8-dev \
-    python3.8-distutils \
     golang \
     pkg-config \
-    && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo ln -sf /usr/bin/python3.8 /usr/bin/python \
-    && sudo ln -sf /usr/bin/python3.8 /usr/bin/python3 \
-    && wget --no-check-certificate --quiet -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
-    && sudo python3.8 /tmp/get-pip.py \
-    && sudo python3.8 -m pip install --upgrade pip \
-    && sudo python3.8 -m pip install "virtualenv<20.0.0" \
-    && sudo python3.8 -m pip install PyGithub \
-    && sudo python3.8 -m pip install meson
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 2.7.16 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.5.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.9 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.1 \
+    && pyenv global 3.8.1
+
+RUN python --version \
+    && pip --version \
+    && python -m pip install --upgrade pip \
+    && python -m pip install "virtualenv<20.0.0" PyGithub meson conan
 
 USER conan
 WORKDIR /home/conan

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -3,24 +3,16 @@ FROM conanio/gcc5
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
 RUN sudo apt-get update \
-    && sudo apt-get -qq install -y --no-install-recommends software-properties-common \
-    && sudo add-apt-repository ppa:deadsnakes/ppa -y \
-    && sudo apt-get update \
-    && sudo apt-get -qq install -y --no-install-recommends \
-    golang \
-    pkg-config \
-    && sudo rm -rf /var/lib/apt/lists/*
-
-RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 2.7.16 \
+    && sudo apt-get -qq install -y --no-install-recommends golang pkg-config \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 2.7.16 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.5.7 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.9 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.1 \
-    && pyenv global 3.8.1
-
-RUN python --version \
+    && pyenv global 3.8.1 \
+    && python --version \
     && pip --version \
-    && python -m pip install --upgrade pip \
-    && python -m pip install "virtualenv<20.0.0" PyGithub meson conan
+    && python -m pip install --upgrade pip "virtualenv<20.0.0" PyGithub conan meson
 
 USER conan
 WORKDIR /home/conan

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -10,8 +10,6 @@ RUN sudo apt-get update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.9 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.1 \
     && pyenv global 3.8.1 \
-    && python --version \
-    && pip --version \
     && python -m pip install --upgrade pip "virtualenv<20.0.0" PyGithub conan meson
 
 USER conan

--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -9,13 +9,8 @@ RUN sudo apt-get update \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.5.7 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.9 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.1 \
-    && pyenv global 3.8.1
-
-RUN python -m pip install --upgrade pip
-RUN python -m pip install meson
-RUN python -m pip install "virtualenv<20.0.0"
-RUN python -m pip install PyGithub
-RUN python -m pip install conan
+    && pyenv global 3.8.1 \
+    && python -m pip install --upgrade pip "virtualenv<20.0.0" PyGithub conan meson
 
 USER conan
 WORKDIR /home/conan


### PR DESCRIPTION
Unfortunately, #245 broke ConanCI tests.

We needed to update conanio/conantests because get-pip.py now uses f-string (since 3.6), but the default version was 3.5.

Also, conantests has a mix of python versions from APT and pyenv. This mess caused a confusion in my mind. I forced /usr/bin/python3.8 as default version, but actually the default python runner is provided by pyenv (3.5.7).

As we are running pyenv, I believe those python versions from APT are unnecessary, we can install all them from pyenv and activate when necessary. 

From now, it will run Python 3.8.1 by default. But older versions are all installed too.

/cc @Croydon 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
