### PR TITLE
Validate essential packages

### DIFF
--- a/build.py
+++ b/build.py
@@ -182,6 +182,7 @@ class ConanDockerTools(object):
                 self.test_jenkins()
             else:
                 self.test_linux(arch, compiler_name, compiler_version, distro)
+                self.test_essential_packages()
         finally:
             subprocess.call("docker stop %s" % self.service, shell=True)
             subprocess.call("docker rm %s" % self.service, shell=True)
@@ -302,7 +303,6 @@ class ConanDockerTools(object):
 
     def test_server(self):
         """Validate Conan Server image
-        :param service: Docker compose service name
         """
         logging.info("Testing Docker running service %s." % self.service)
         try:
@@ -315,6 +315,13 @@ class ConanDockerTools(object):
         finally:
             subprocess.call("docker stop %s" % self.service, shell=True)
             subprocess.call("docker rm %s" % self.service, shell=True)
+
+    def test_essential_packages(self):
+        """ Validate essential system packages expected in any Docker image
+        """
+        commands = ["pkg-config", "sudo", "wget", "svn", "git", "make", "autoreconf", "curl", "lzma", "jfrog"]
+        for command in commands:
+            subprocess.check_call("docker exec %s %s --version" % (self.service, command), shell=True)
 
     def deploy(self):
         """Upload Docker image to dockerhub

--- a/build.py
+++ b/build.py
@@ -319,7 +319,7 @@ class ConanDockerTools(object):
     def test_essential_packages(self):
         """ Validate essential system packages expected in any Docker image
         """
-        commands = ["pkg-config", "sudo", "wget", "svn", "git", "make", "autoreconf", "curl", "lzma", "jfrog"]
+        commands = ["pkg-config", "sudo", "wget", "svn", "git", "make", "autoreconf", "curl", "lzma", "jfrog", "cmake"]
         for command in commands:
             subprocess.check_call("docker exec %s %s --version" % (self.service, command), shell=True)
 


### PR DESCRIPTION
The PR #248 was fix because we didn't check essential packages present in all Docker images. Some packages system required, like wget and curl, but others a CCI requirement, like jfrog-cli.

/cc @Croydon 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
