### PR TITLE
Deprecated old docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ The images are uploaded to Docker Hub:
 #### GCC
 | Version                                                                                       | Arch    |  Status, Life cycle  |
 |-----------------------------------------------------------------------------------------------|---------|------------|
-| [conanio/gcc46: gcc 4.6](https://hub.docker.com/r/conanio/gcc46/)                     | x86_64  |  Supported |
-| [conanio/gcc48: gcc 4.8](https://hub.docker.com/r/conanio/gcc48/)                     | x86_64  |  Supported |
-| [conanio/gcc48-x86: gcc 4.8](https://hub.docker.com/r/conanio/gcc48-x86/)             | x86     |  Supported |
-| [conanio/gcc49: gcc 4.9](https://hub.docker.com/r/conanio/gcc49/)                     | x86_64  |  Supported |
-| [conanio/gcc49-x86: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-x86/)             | x86     |  Supported |
-| [conanio/gcc49-armv7: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7/)         | armv7   |  Supported |
-| [conanio/gcc49-armv7hf: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7hf/)     | armv7hf |  Supported |
-| [conanio/gcc52: gcc 5.2](https://hub.docker.com/r/conanio/gcc52/)                     | x86_64  |  Supported |
-| [conanio/gcc53: gcc 5.3](https://hub.docker.com/r/conanio/gcc53/)                     | x86_64  | Supported  |
-| [conanio/gcc54: gcc 5.4](https://hub.docker.com/r/conanio/gcc54/)                     | x86_64  | Supported  |
-| [conanio/gcc63: gcc 6.3](https://hub.docker.com/r/conanio/gcc63/)                     | x86_64  | Supported  |
-| [conanio/gcc64: gcc 6.4](https://hub.docker.com/r/conanio/gcc64/)                     | x86_64  | Supported  |
-| [conanio/gcc72: gcc 7.2](https://hub.docker.com/r/conanio/gcc72/)                     | x86_64  | Supported  |
+| [conanio/gcc46: gcc 4.6](https://hub.docker.com/r/conanio/gcc46/)                     | x86_64  |  Deprecated |
+| [conanio/gcc48: gcc 4.8](https://hub.docker.com/r/conanio/gcc48/)                     | x86_64  |  Deprecated |
+| [conanio/gcc48-x86: gcc 4.8](https://hub.docker.com/r/conanio/gcc48-x86/)             | x86     |  Deprecated |
+| [conanio/gcc49: gcc 4.9](https://hub.docker.com/r/conanio/gcc49/)                     | x86_64  |  Deprecated |
+| [conanio/gcc49-x86: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-x86/)             | x86     |  Deprecated |
+| [conanio/gcc49-armv7: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7/)         | armv7   |  Deprecated |
+| [conanio/gcc49-armv7hf: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7hf/)     | armv7hf |  Deprecated |
+| [conanio/gcc52: gcc 5.2](https://hub.docker.com/r/conanio/gcc52/)                     | x86_64  |  Deprecated |
+| [conanio/gcc53: gcc 5.3](https://hub.docker.com/r/conanio/gcc53/)                     | x86_64  | Deprecated  |
+| [conanio/gcc54: gcc 5.4](https://hub.docker.com/r/conanio/gcc54/)                     | x86_64  | Deprecated  |
+| [conanio/gcc63: gcc 6.3](https://hub.docker.com/r/conanio/gcc63/)                     | x86_64  | Deprecated  |
+| [conanio/gcc64: gcc 6.4](https://hub.docker.com/r/conanio/gcc64/)                     | x86_64  | Deprecated  |
+| [conanio/gcc72: gcc 7.2](https://hub.docker.com/r/conanio/gcc72/)                     | x86_64  | Deprecated  |
 
 
 GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are generic images by major version. If you are interested to understand the motivation, read this [issue](https://github.com/conan-io/conan/issues/1214).
@@ -65,8 +65,8 @@ GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are
 
 | Version                                                                                       | Arch   |  Status, Life cycle  |
 |-----------------------------------------------------------------------------------------------|--------|------------|
-| - [conanio/clang38: clang 3.8](https://hub.docker.com/r/conanio/clang38/)             | x86_64 |  Supported |
-| - [conanio/clang39-x86: clang 3.9](https://hub.docker.com/r/conanio/clang39-x86/)     | x86    |  Supported |
+| - [conanio/clang38: clang 3.8](https://hub.docker.com/r/conanio/clang38/)             | x86_64 |  Deprecated |
+| - [conanio/clang39-x86: clang 3.9](https://hub.docker.com/r/conanio/clang39-x86/)     | x86    |  Deprecated |
 | - [conanio/clang39: clang 3.9](https://hub.docker.com/r/conanio/clang39/)             | x86_64 |  Supported |
 | - [conanio/clang40-x86: clang 4.0](https://hub.docker.com/r/conanio/clang40-x86)      | x86    |  Supported |
 | - [conanio/clang40: clang 4.0](https://hub.docker.com/r/conanio/clang40/)             | x86_64 |  Supported |

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The images are uploaded to Docker Hub:
 | [conanio/gcc46: gcc 4.6](https://hub.docker.com/r/conanio/gcc46/)                     | x86_64  |  Deprecated |
 | [conanio/gcc48: gcc 4.8](https://hub.docker.com/r/conanio/gcc48/)                     | x86_64  |  Deprecated |
 | [conanio/gcc48-x86: gcc 4.8](https://hub.docker.com/r/conanio/gcc48-x86/)             | x86     |  Deprecated |
-| [conanio/gcc49: gcc 4.9](https://hub.docker.com/r/conanio/gcc49/)                     | x86_64  |  Deprecated |
-| [conanio/gcc49-x86: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-x86/)             | x86     |  Deprecated |
-| [conanio/gcc49-armv7: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7/)         | armv7   |  Deprecated |
-| [conanio/gcc49-armv7hf: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7hf/)     | armv7hf |  Deprecated |
+| [conanio/gcc49: gcc 4.9](https://hub.docker.com/r/conanio/gcc49/)                     | x86_64  |  Supported |
+| [conanio/gcc49-x86: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-x86/)             | x86     |  Supported |
+| [conanio/gcc49-armv7: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7/)         | armv7   |  Supported |
+| [conanio/gcc49-armv7hf: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7hf/)     | armv7hf |  Supported |
 | [conanio/gcc52: gcc 5.2](https://hub.docker.com/r/conanio/gcc52/)                     | x86_64  |  Deprecated |
 | [conanio/gcc53: gcc 5.3](https://hub.docker.com/r/conanio/gcc53/)                     | x86_64  | Deprecated  |
 | [conanio/gcc54: gcc 5.4](https://hub.docker.com/r/conanio/gcc54/)                     | x86_64  | Deprecated  |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The images are uploaded to Docker Hub:
 | [conanio/gcc48: gcc 4.8](https://hub.docker.com/r/conanio/gcc48/)                     | x86_64  |  Deprecated |
 | [conanio/gcc48-x86: gcc 4.8](https://hub.docker.com/r/conanio/gcc48-x86/)             | x86     |  Deprecated |
 | [conanio/gcc49: gcc 4.9](https://hub.docker.com/r/conanio/gcc49/)                     | x86_64  |  Supported |
-| [conanio/gcc49-x86: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-x86/)             | x86     |  Supported |
+| [conanio/gcc49-x86: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-x86/)             | x86     |  Deprecated |
 | [conanio/gcc49-armv7: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7/)         | armv7   |  Supported |
 | [conanio/gcc49-armv7hf: gcc 4.9](https://hub.docker.com/r/conanio/gcc49-armv7hf/)     | armv7hf |  Supported |
 | [conanio/gcc52: gcc 5.2](https://hub.docker.com/r/conanio/gcc52/)                     | x86_64  |  Deprecated |
@@ -34,25 +34,25 @@ GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are
 | Version                                                                                    | Arch    |  Status, Life cycle  |
 |--------------------------------------------------------------------------------------------|---------|----------------------|
 | [conanio/gcc5: gcc 5](https://hub.docker.com/r/conanio/gcc5/)                      | x86_64  |  Supported           |
-| [conanio/gcc5-x86: gcc 5](https://hub.docker.com/r/conanio/gcc5-x86/)              | x86     |  Supported           |
+| [conanio/gcc5-x86: gcc 5](https://hub.docker.com/r/conanio/gcc5-x86/)              | x86     |  Deprecated          |
 | [conanio/gcc5-armv7: gcc 5](https://hub.docker.com/r/conanio/gcc5-armv7/)          | armv7   |  Supported           |
 | [conanio/gcc5-armv7hf: gcc 5](https://hub.docker.com/r/conanio/gcc5-armv7hf/)      | armv7hf |  Supported           |
 | [conanio/gcc6: gcc 6](https://hub.docker.com/r/conanio/gcc6/)                      | x86_64  |  Supported           |
-| [conanio/gcc6-x86: gcc 6](https://hub.docker.com/r/conanio/gcc6-x86/)              | x86     |  Supported           |
+| [conanio/gcc6-x86: gcc 6](https://hub.docker.com/r/conanio/gcc6-x86/)              | x86     |  Deprecated          |
 | [conanio/gcc6-armv7: gcc 6](https://hub.docker.com/r/conanio/gcc6-armv7/)          | armv7   |  Supported           |
 | [conanio/gcc6-armv7hf: gcc 6](https://hub.docker.com/r/conanio/gcc6-armv7hf/)      | armv7hf |  Supported           |
-| [conanio/gcc7-x86: gcc 7](https://hub.docker.com/r/conanio/gcc7-x86/)              | x86     |  Supported           |
+| [conanio/gcc7-x86: gcc 7](https://hub.docker.com/r/conanio/gcc7-x86/)              | x86     |  Deprecated          |
 | [conanio/gcc7: gcc 7](https://hub.docker.com/r/conanio/gcc7/)                      | x86_64  |  Supported           |
 | [conanio/gcc7-centos6: gcc 7](https://hub.docker.com/r/conanio/gcc7-centos6/)      | x86_64  |  Deprecated          |
 | [conanio/gcc7-centos6-x86: gcc 7](https://hub.docker.com/r/conanio/gcc7-centos6-x86/) | x86  |  Deprecated          |
 | [conanio/gcc7-mingw: gcc 7](https://hub.docker.com/r/conanio/gcc7-mingw/)          | x86_64  |  Supported           |
 | [conanio/gcc7-armv7: gcc 7](https://hub.docker.com/r/conanio/gcc7-armv7/)          | armv7   |  Supported           |
 | [conanio/gcc7-armv7hf: gcc 7](https://hub.docker.com/r/conanio/gcc7-armv7hf/)      | armv7hf |  Supported           |
-| [conanio/gcc8-x86: gcc 8](https://hub.docker.com/r/conanio/gcc8-x86/)              | x86     |  Supported           |
+| [conanio/gcc8-x86: gcc 8](https://hub.docker.com/r/conanio/gcc8-x86/)              | x86     |  Deprecated          |
 | [conanio/gcc8: gcc 8](https://hub.docker.com/r/conanio/gcc8/)                      | x86_64  |  Supported           |
 | [conanio/gcc8-armv7: gcc 8](https://hub.docker.com/r/conanio/gcc8-armv7/)          | armv7   |  Supported           |
 | [conanio/gcc8-armv7hf: gcc 8](https://hub.docker.com/r/conanio/gcc8-armv7hf/)      | armv7hf |  Supported           |
-| [conanio/gcc9-x86: gcc 9](https://hub.docker.com/r/conanio/gcc9-x86/)              | x86     |  Supported           |
+| [conanio/gcc9-x86: gcc 9](https://hub.docker.com/r/conanio/gcc9-x86/)              | x86     |  Deprecated          |
 | [conanio/gcc9: gcc 9](https://hub.docker.com/r/conanio/gcc9/)                      | x86_64  |  Supported           |
 | [conanio/gcc9-armv7: gcc 9](https://hub.docker.com/r/conanio/gcc9-armv7/)          | armv7   |  Supported           |
 | [conanio/gcc9-armv7hf: gcc 9](https://hub.docker.com/r/conanio/gcc9-armv7hf/)      | armv7hf |  Supported           |
@@ -67,20 +67,20 @@ GCC>=5 is ABI compatible for minor versions. To solve multiple minors, there are
 |-----------------------------------------------------------------------------------------------|--------|------------|
 | - [conanio/clang38: clang 3.8](https://hub.docker.com/r/conanio/clang38/)             | x86_64 |  Deprecated |
 | - [conanio/clang39-x86: clang 3.9](https://hub.docker.com/r/conanio/clang39-x86/)     | x86    |  Deprecated |
-| - [conanio/clang39: clang 3.9](https://hub.docker.com/r/conanio/clang39/)             | x86_64 |  Supported |
-| - [conanio/clang40-x86: clang 4.0](https://hub.docker.com/r/conanio/clang40-x86)      | x86    |  Supported |
-| - [conanio/clang40: clang 4.0](https://hub.docker.com/r/conanio/clang40/)             | x86_64 |  Supported |
-| - [conanio/clang50-x86: clang 5.0](https://hub.docker.com/r/conanio/clang50-x86/)     | x86    |  Supported |
-| - [conanio/clang50: clang 5.0](https://hub.docker.com/r/conanio/clang50/)             | x86_64 |  Supported |
-| - [conanio/clang60-x86: clang 6.0](https://hub.docker.com/r/conanio/clang60-x86/)     | x86    |  Supported |
-| - [conanio/clang60: clang 6.0](https://hub.docker.com/r/conanio/clang60/)             | x86_64 |  Supported |
-| - [conanio/clang7-x86: clang 7](https://hub.docker.com/r/conanio/clang7-x86/)         | x86    |  Supported |
-| - [conanio/clang7: clang 7](https://hub.docker.com/r/conanio/clang7/)                 | x86_64 |  Supported |
-| - [conanio/clang8-x86: clang 8](https://hub.docker.com/r/conanio/clang8-x86/)         | x86    |  Supported |
-| - [conanio/clang8: clang 8](https://hub.docker.com/r/conanio/clang8/)                 | x86_64 |  Supported |
-| - [conanio/clang9-x86: clang 9](https://hub.docker.com/r/conanio/clang9-x86/)         | x86    |  Supported |
-| - [conanio/clang9: clang 9](https://hub.docker.com/r/conanio/clang9/)                 | x86_64 |  Supported |
-| - [conanio/clang10: clang 10](https://hub.docker.com/r/conanio/clang10/)              | x86_64 |  Supported |
+| - [conanio/clang39: clang 3.9](https://hub.docker.com/r/conanio/clang39/)             | x86_64 |  Supported  |
+| - [conanio/clang40-x86: clang 4.0](https://hub.docker.com/r/conanio/clang40-x86)      | x86    |  Deprecated |
+| - [conanio/clang40: clang 4.0](https://hub.docker.com/r/conanio/clang40/)             | x86_64 |  Supported  |
+| - [conanio/clang50-x86: clang 5.0](https://hub.docker.com/r/conanio/clang50-x86/)     | x86    |  Deprecated |
+| - [conanio/clang50: clang 5.0](https://hub.docker.com/r/conanio/clang50/)             | x86_64 |  Supported  |
+| - [conanio/clang60-x86: clang 6.0](https://hub.docker.com/r/conanio/clang60-x86/)     | x86    |  Deprecated |
+| - [conanio/clang60: clang 6.0](https://hub.docker.com/r/conanio/clang60/)             | x86_64 |  Supported  |
+| - [conanio/clang7-x86: clang 7](https://hub.docker.com/r/conanio/clang7-x86/)         | x86    |  Deprecated |
+| - [conanio/clang7: clang 7](https://hub.docker.com/r/conanio/clang7/)                 | x86_64 |  Supported  |
+| - [conanio/clang8-x86: clang 8](https://hub.docker.com/r/conanio/clang8-x86/)         | x86    |  Deprecated |
+| - [conanio/clang8: clang 8](https://hub.docker.com/r/conanio/clang8/)                 | x86_64 |  Supported  |
+| - [conanio/clang9-x86: clang 9](https://hub.docker.com/r/conanio/clang9-x86/)         | x86    |  Deprecated |
+| - [conanio/clang9: clang 9](https://hub.docker.com/r/conanio/clang9/)                 | x86_64 |  Supported  |
+| - [conanio/clang10: clang 10](https://hub.docker.com/r/conanio/clang10/)              | x86_64 |  Supported  |
 
 
 #### Visual Studio
@@ -94,10 +94,10 @@ However, you can download the Docker recipe and build.
 
 | Version                                                                                       | Arch   |  Status, Life cycle  |
 |-----------------------------------------------------------------------------------------------|--------|------------|
-| - [conanio/android-clang8: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8/)             | x86_64 |  Supported |
-| - [conanio/android-clang8-x86: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-x86/)     | x86    |  Supported |
-| - [conanio/android-clang8-armv7: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-armv7/) | x86    |  Supported |
-| - [conanio/android-clang8-armv8: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-armv8/) | x86    |  Supported |
+| - [conanio/android-clang8: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8/)             | x86_64 |  Supported  |
+| - [conanio/android-clang8-x86: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-x86/)     | x86    |  Deprecated |
+| - [conanio/android-clang8-armv7: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-armv7/) | x86    |  Supported  |
+| - [conanio/android-clang8-armv8: Android clang 3.8](https://hub.docker.com/r/conanio/android-clang8-armv8/) | x86    |  Supported  |
 
 
 #### Conan Server

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,16 +20,6 @@ jobs:
         DOCKER_ARCHS: "x86_64"
         DOCKER_DISTRO: "mingw"
 
-      Ubuntu GCC 4.6:
-        GCC_VERSIONS: "4.6"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 4.8:
-        GCC_VERSIONS: "4.8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 4.8 x86:
-        GCC_VERSIONS: "4.8"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 4.9:
         GCC_VERSIONS: "4.9"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf"
@@ -46,10 +36,6 @@ jobs:
         GCC_VERSIONS: "5"
         DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 5.2 x86_64:
-        GCC_VERSIONS: "5.2"
-      Ubuntu GCC 5.3 x86_64:
-        GCC_VERSIONS: "5.3"
       Ubuntu GCC 6:
         GCC_VERSIONS: "6"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
@@ -58,10 +44,6 @@ jobs:
         GCC_VERSIONS: "6"
         DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 6.3 x86_64:
-        GCC_VERSIONS: "6.3"
-      Ubuntu GCC 6.4 x86_64:
-        GCC_VERSIONS: "6.4"
       Ubuntu GCC 7:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
@@ -70,8 +52,6 @@ jobs:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 7.2 x86_64:
-        GCC_VERSIONS: "7.2"
       Ubuntu GCC 8:
         GCC_VERSIONS: "8"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
@@ -93,8 +73,6 @@ jobs:
         DOCKER_ARCHS: "x86_64,armv7,armv7hf"
         DOCKER_DISTRO: "jnlp-slave"
 
-      Ubuntu Clang 3.8 x86_64:
-        CLANG_VERSIONS: "3.8"
       Ubuntu Clang 3.9 x86_64:
         CLANG_VERSIONS: "3.9"
         DOCKER_DISTRO: "jnlp-slave"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,49 +24,24 @@ jobs:
         GCC_VERSIONS: "4.9"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 4.9 x86:
-        GCC_VERSIONS: "4.9"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 5:
         GCC_VERSIONS: "5"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 5 x86:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 6:
         GCC_VERSIONS: "6"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 6 x86:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 7:
         GCC_VERSIONS: "7"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 7 x86:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 8:
         GCC_VERSIONS: "8"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 8 x86:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 9:
         GCC_VERSIONS: "9"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 9 x86:
-        GCC_VERSIONS: "9"
-        DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
       Ubuntu GCC 10:
         GCC_VERSIONS: "10"
@@ -76,51 +51,23 @@ jobs:
       Ubuntu Clang 3.9 x86_64:
         CLANG_VERSIONS: "3.9"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 3.9 x86:
-        CLANG_VERSIONS: "3.9"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 4.0 x86_64:
         CLANG_VERSIONS: "4.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 4.0 x86:
-        CLANG_VERSIONS: "4.0"
-        DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 5.0 x86_64:
         CLANG_VERSIONS: "5.0"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 5.0 x86:
-        CLANG_VERSIONS: "5.0"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 6.0 x86_64:
         CLANG_VERSIONS: "6.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 6.0 x86:
-        CLANG_VERSIONS: "6.0"
-        DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 7 x86_64:
         CLANG_VERSIONS: "7"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 7 x86:
-        CLANG_VERSIONS: "7"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 8 x86_64:
         CLANG_VERSIONS: "8"
         DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 8 x86:
-        CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "x86"
-        DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 9 x86_64:
         CLANG_VERSIONS: "9"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 9 x86:
-        CLANG_VERSIONS: "9"
-        DOCKER_ARCHS: "x86"
         DOCKER_DISTRO: "jnlp-slave"
       Ubuntu Clang 10 x86_64:
         CLANG_VERSIONS: "10"
@@ -132,7 +79,7 @@ jobs:
       Android Clang 8:
         DOCKER_CROSS: "android"
         CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64,x86,armv7,armv8"
+        DOCKER_ARCHS: "x86_64,armv7,armv8"
 
       Conan Server:
         BUILD_CONAN_SERVER_IMAGE: 1


### PR DESCRIPTION
Some images are no longer used by CCI and now caused errors to https://github.com/conan-io/conan-docker-tools/pull/249 because we need to install JFrog CLI. 

We could install, but thinking about, I think it's a good opportunity to remove old images which are no longer used.

We can keep the recipes, as for Windows, so anyone is able to build from sources. But distributing will no longer available.

closes #240

/cc @Croydon 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
