### PR TITLE
Install libc++-11 with clang-11

### DIFF
--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -36,8 +36,8 @@ RUN dpkg --add-architecture i386 \
     && rm llvm.sh \
     # Further LLVM packages not installed by the llvm.sh script
     && apt-get install -y --no-install-recommends \
-       libc++-dev \
-       libc++abi-dev \
+       libc++-11-dev \
+       libc++abi-11-dev \
     && apt-get remove -y lsb-release software-properties-common \
     # Install dependencies of Python
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Changelog: Fix: This is to install libc++-11 instead of default one (6 or 7, very old)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.

fixes #251