### PR TITLE
Rebuild all 1.35.2 for aligment

### DIFF
--- a/build.py
+++ b/build.py
@@ -200,7 +200,7 @@ class ConanDockerTools(object):
         :param compiler_name: Compiler to be specified as conan setting e.g. clang
         :param compiler_version: Compiler version to be specified as conan setting e.g. 3.8
         """
-        subprocess.check_call("docker exec %s %s pip -q install -U conan" % (self.service, self.variables.sudo_command), shell=True)
+        subprocess.check_call("docker exec %s %s pip -q install -U conan==%s" % (self.service, self.variables.sudo_command, self.variables.docker_build_tag), shell=True)
         subprocess.check_call("docker exec %s %s pip -q install -U conan_package_tools" % (self.service, self.variables.sudo_command), shell=True)
         subprocess.check_call("docker exec %s conan user" % self.service, shell=True)
 
@@ -264,9 +264,10 @@ class ConanDockerTools(object):
                 (self.service, sudo_command),
                 shell=True)
             subprocess.check_call(
-                "docker exec %s %s pip install --no-cache-dir -U conan" % (self.service,
-                                                                        sudo_command),
-                shell=True)
+                "docker exec %s %s pip install --no-cache-dir -U conan==%s" % (self.service,
+                                                                        sudo_command,
+                                                                        self.variables.docker_build_tag),
+                                                                        shell=True)
             subprocess.check_call("docker exec %s conan user" % self.service, shell=True)
 
             if compiler_name == "clang" and compiler_version == "7":

--- a/build.py
+++ b/build.py
@@ -13,7 +13,7 @@ from cpt.ci_manager import CIManager
 from cpt.printer import Printer
 
 
-TARGET_CONAN_VERSION = "1.36.0"
+TARGET_CONAN_VERSION = "1.35.2"
 
 
 class ConanDockerTools(object):


### PR DESCRIPTION
Just to enforce all 1.35.2 images are running the correct Conan client version.


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
