### PR TITLE
Fix Jfrog cli download

### DIFF
--- a/clang_10/Dockerfile
+++ b/clang_10/Dockerfile
@@ -63,7 +63,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_11/Dockerfile
+++ b/clang_11/Dockerfile
@@ -63,7 +63,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-${LLVM_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_3.9/Dockerfile
+++ b/clang_3.9/Dockerfile
@@ -72,7 +72,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_4.0/Dockerfile
+++ b/clang_4.0/Dockerfile
@@ -71,7 +71,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_5.0/Dockerfile
+++ b/clang_5.0/Dockerfile
@@ -67,7 +67,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_6.0/Dockerfile
+++ b/clang_6.0/Dockerfile
@@ -65,7 +65,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -67,7 +67,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -65,7 +65,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -67,7 +67,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_10/Dockerfile
+++ b/gcc_10/Dockerfile
@@ -48,7 +48,8 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_11/Dockerfile
+++ b/gcc_11/Dockerfile
@@ -51,7 +51,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     && rm -rf /var/lib/apt/lists/* \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -57,7 +57,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -52,7 +52,8 @@ RUN dpkg --add-architecture i386 \
        && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
        && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
        && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+       && curl -fL https://getcli.jfrog.io | sh \
+       && mv jfrog /usr/local/bin/jfrog \
        && chmod +x /usr/local/bin/jfrog \
        && groupadd 1001 -g 1001 \
        && groupadd 1000 -g 1000 \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -60,7 +60,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -58,7 +58,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -58,7 +58,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -60,7 +60,8 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && wget -q --no-check-certificate -O /usr/local/bin/jfrog https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 \
+    && curl -fL https://getcli.jfrog.io | sh \
+    && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd 1001 -g 1001 \
     && groupadd 1000 -g 1000 \


### PR DESCRIPTION
The current JFrog CLI url returns HTTP 403 Error. Let's use the official script.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
