### PR TITLE
Validate installed and not installed tools for new Docker images

### DIFF
--- a/modern/tests/fixtures/expected.py
+++ b/modern/tests/fixtures/expected.py
@@ -61,9 +61,20 @@ class Expected:
     docker_tag: str
     python: Version
     cmake: Version
+    pkg_config: Version
+    make: Version
+    autoconf: Version
+    perl: Version
+    wget: Version
+    curl: Version
+    git: Version
+    subversion: Version
+    xzutils: Version
+    nasm: Version
     conan: Version = None
     compiler: Compiler = None
     compiler_versions: defaultdict(list) = None
+
 
     def __str__(self):
         return f"""
@@ -76,6 +87,16 @@ class Expected:
             - conan: {self.conan}
             - compiler: {self.compiler}
             - compiler_versions: {self.compiler_versions}
+            - pkg_config: {self.pkg_config}
+            - make: {self.make}
+            - autoconf: {self.autoconf}
+            - perl: {self.perl}
+            - wget: {self.wget}
+            - curl: {self.curl}
+            - git: {self.git}
+            - subversion: {self.subversion}
+            - xzutils: {self.xzutils}
+            - nasm: {self.nasm}
         """
 
     def vanilla_image(self):
@@ -132,7 +153,20 @@ def expected(request) -> Expected:
     distro = Distro(m.group('distro'), Version(m.group('distro_version')))
     python = Version(env_values.get('PYTHON_VERSION'))
     cmake = Version(env_values.get('CMAKE_VERSION_FULL'))
-    expected = Expected(distro, m.group('username'), m.group('tag'), python, cmake)
+    pkg_config = Version("0.29.1")
+    make = Version("4.1")
+    autoconf = Version("2.69")
+    perl = Version("5.22.1")
+    wget = Version("1.17.1")
+    curl = Version("7.47.0")
+    git = Version("2.7.4")
+    subversion = Version("1.9.3")
+    xzutils = Version("5.1.0alpha")
+    nasm = Version("2.11.08")
+
+    expected = Expected(distro, m.group('username'), m.group('tag'), python, cmake,
+                        pkg_config, make, autoconf, perl, wget, curl, git, subversion,
+                        xzutils, nasm)
     expected.conan = Version(env_values.get('CONAN_VERSION'))
     expected.compiler_versions = get_compiler_versions()
 

--- a/modern/tests/fixtures/expected.py
+++ b/modern/tests/fixtures/expected.py
@@ -61,20 +61,9 @@ class Expected:
     docker_tag: str
     python: Version
     cmake: Version
-    pkg_config: Version
-    make: Version
-    autoconf: Version
-    perl: Version
-    wget: Version
-    curl: Version
-    git: Version
-    subversion: Version
-    xzutils: Version
-    nasm: Version
     conan: Version = None
     compiler: Compiler = None
     compiler_versions: defaultdict(list) = None
-
 
     def __str__(self):
         return f"""
@@ -87,16 +76,6 @@ class Expected:
             - conan: {self.conan}
             - compiler: {self.compiler}
             - compiler_versions: {self.compiler_versions}
-            - pkg_config: {self.pkg_config}
-            - make: {self.make}
-            - autoconf: {self.autoconf}
-            - perl: {self.perl}
-            - wget: {self.wget}
-            - curl: {self.curl}
-            - git: {self.git}
-            - subversion: {self.subversion}
-            - xzutils: {self.xzutils}
-            - nasm: {self.nasm}
         """
 
     def vanilla_image(self):
@@ -153,20 +132,7 @@ def expected(request) -> Expected:
     distro = Distro(m.group('distro'), Version(m.group('distro_version')))
     python = Version(env_values.get('PYTHON_VERSION'))
     cmake = Version(env_values.get('CMAKE_VERSION_FULL'))
-    pkg_config = Version("0.29.1")
-    make = Version("4.1")
-    autoconf = Version("2.69")
-    perl = Version("5.22.1")
-    wget = Version("1.17.1")
-    curl = Version("7.47.0")
-    git = Version("2.7.4")
-    subversion = Version("1.9.3")
-    xzutils = Version("5.1.0alpha")
-    nasm = Version("2.11.08")
-
-    expected = Expected(distro, m.group('username'), m.group('tag'), python, cmake,
-                        pkg_config, make, autoconf, perl, wget, curl, git, subversion,
-                        xzutils, nasm)
+    expected = Expected(distro, m.group('username'), m.group('tag'), python, cmake)
     expected.conan = Version(env_values.get('CONAN_VERSION'))
     expected.compiler_versions = get_compiler_versions()
 

--- a/modern/tests/test_installed/test_installed.py
+++ b/modern/tests/test_installed/test_installed.py
@@ -1,75 +1,35 @@
+import pytest
+
+
+expected_versions = {
+    "pkg-config": {"16.04": "0.29.1"},
+    "make": {"16.04": "4.1"},
+    "autoconf": {"16.04": "2.69"},
+    "autoreconf": {"16.04": "2.69"},
+    "perl": {"16.04": "5.22.1"},
+    "wget": {"16.04": "1.17.1"},
+    "curl": {"16.04": "7.47.0"},
+    "git": {"16.04": "2.7.4"},
+    "svn": {"16.04": "1.9.3"},
+    "xz": {"16.04": "5.1.0"},
+    "nasm": {"16.04": "2.11.08"},
+}
+
+
 def test_cmake_version(container, expected):
-    output, _ = container.exec(['cmake', '--version'])
+    output, _ = container.exec(["cmake", "--version"])
     first_line = output.splitlines()[0]
-    assert first_line.strip() == f'cmake version {expected.cmake}'
+    assert first_line.strip() == f"cmake version {expected.cmake}"
 
 
 def test_python_version(container, expected):
-    output, _ = container.exec(['python', '--version'])
-    assert output.strip() == f'Python {expected.python}'
+    output, _ = container.exec(["python", "--version"])
+    assert output.strip() == f"Python {expected.python}"
 
 
-def test_pkg_config(container, expected):
-    output, _ = container.exec(["pkg-config", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"{expected.pkg_config}"
-
-
-def test_make(container, expected):
-    output, _ = container.exec(["make", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"GNU Make {expected.make}"
-
-
-def test_autoconf(container, expected):
-    output, _ = container.exec(["autoconf", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"autoconf (GNU Autoconf) {expected.autoconf}"
-
-
-def test_autoreconf(container, expected):
-    output, _ = container.exec(["autoreconf", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"autoreconf (GNU Autoconf) {expected.autoconf}"
-
-
-def test_perl(container, expected):
-    output, _ = container.exec(["perl", "--version"])
-    first_line = output.splitlines()[1]
-    assert f"v{expected.perl}" in first_line.strip()
-
-
-def test_wget(container, expected):
-    output, _ = container.exec(["wget", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"GNU Wget {expected.wget} built on linux-gnu."
-
-
-def test_curl(container, expected):
-    output, _ = container.exec(["curl", "--version"])
-    first_line = output.splitlines()[0]
-    assert f"curl {expected.curl}" in first_line.strip()
-
-
-def test_git(container, expected):
-    output, _ = container.exec(["git", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"git version {expected.git}"
-
-
-def test_subversion(container, expected):
-    output, _ = container.exec(["svn", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"svn, version {expected.subversion} (r1718519)"
-
-
-def test_xz_utils(container, expected):
-    output, _ = container.exec(["xz", "--version"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"xz (XZ Utils) {expected.xzutils}"
-
-
-def test_nasm(container, expected):
-    output, _ = container.exec(["nasm", "-v"])
-    first_line = output.splitlines()[0]
-    assert first_line.strip() == f"NASM version {expected.nasm}"
+@pytest.mark.parametrize("tool", expected_versions.keys())
+def test_installed_system_package_version(container, expected, tool):
+    output, _ = container.exec([tool, "--version"])
+    if output == "":
+        output, _ = container.exec([tool, "-v"])
+    assert expected_versions[tool][expected.distro.version.full_version] in output

--- a/modern/tests/test_installed/test_installed.py
+++ b/modern/tests/test_installed/test_installed.py
@@ -7,3 +7,69 @@ def test_cmake_version(container, expected):
 def test_python_version(container, expected):
     output, _ = container.exec(['python', '--version'])
     assert output.strip() == f'Python {expected.python}'
+
+
+def test_pkg_config(container, expected):
+    output, _ = container.exec(["pkg-config", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"{expected.pkg_config}"
+
+
+def test_make(container, expected):
+    output, _ = container.exec(["make", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"GNU Make {expected.make}"
+
+
+def test_autoconf(container, expected):
+    output, _ = container.exec(["autoconf", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"autoconf (GNU Autoconf) {expected.autoconf}"
+
+
+def test_autoreconf(container, expected):
+    output, _ = container.exec(["autoreconf", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"autoreconf (GNU Autoconf) {expected.autoconf}"
+
+
+def test_perl(container, expected):
+    output, _ = container.exec(["perl", "--version"])
+    first_line = output.splitlines()[1]
+    assert f"v{expected.perl}" in first_line.strip()
+
+
+def test_wget(container, expected):
+    output, _ = container.exec(["wget", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"GNU Wget {expected.wget} built on linux-gnu."
+
+
+def test_curl(container, expected):
+    output, _ = container.exec(["curl", "--version"])
+    first_line = output.splitlines()[0]
+    assert f"curl {expected.curl}" in first_line.strip()
+
+
+def test_git(container, expected):
+    output, _ = container.exec(["git", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"git version {expected.git}"
+
+
+def test_subversion(container, expected):
+    output, _ = container.exec(["svn", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"svn, version {expected.subversion} (r1718519)"
+
+
+def test_xz_utils(container, expected):
+    output, _ = container.exec(["xz", "--version"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"xz (XZ Utils) {expected.xzutils}"
+
+
+def test_nasm(container, expected):
+    output, _ = container.exec(["nasm", "-v"])
+    first_line = output.splitlines()[0]
+    assert first_line.strip() == f"NASM version {expected.nasm}"

--- a/modern/tests/test_installed/test_not_installed.py
+++ b/modern/tests/test_installed/test_not_installed.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        "vim",
+        "vi",
+        "nano",
+        "meson",
+        "ninja",
+        "bazel",
+        "scons",
+        "qmake",
+        "xmake",
+        "premake5",
+        "b2",
+        "java",
+        "lua",
+    ],
+)
+def test_not_installed(container, tool):
+    output, _ = container.exec([tool, "--version"])
+    first_line = output.splitlines()[0]
+    assert f'"{tool}": executable file not found' in first_line.strip()

--- a/modern/tests/test_installed/test_not_installed.py
+++ b/modern/tests/test_installed/test_not_installed.py
@@ -22,4 +22,4 @@ import pytest
 def test_not_installed(container, tool):
     output, _ = container.exec([tool, "--version"])
     first_line = output.splitlines()[0]
-    assert f"\"{tool}\": executable file not found" in first_line.strip()
+    assert f'exec: \\\\"{tool}\\\\": executable file not found in $PATH' in first_line.strip()

--- a/modern/tests/test_installed/test_not_installed.py
+++ b/modern/tests/test_installed/test_not_installed.py
@@ -22,4 +22,4 @@ import pytest
 def test_not_installed(container, tool):
     output, _ = container.exec([tool, "--version"])
     first_line = output.splitlines()[0]
-    assert f'"{tool}": executable file not found' in first_line.strip()
+    assert f"\"{tool}\": executable file not found" in first_line.strip()

--- a/modern/tests/test_installed/test_not_installed.py
+++ b/modern/tests/test_installed/test_not_installed.py
@@ -22,4 +22,4 @@ import pytest
 def test_not_installed(container, tool):
     output, _ = container.exec([tool, "--version"])
     first_line = output.splitlines()[0]
-    assert f'exec: \\\\"{tool}\\\\": executable file not found in $PATH' in first_line.strip()
+    assert f'exec: \\"{tool}\\": executable file not found in $PATH' in first_line.strip()

--- a/modern/tests/test_installed/test_not_installed.py
+++ b/modern/tests/test_installed/test_not_installed.py
@@ -15,7 +15,6 @@ import pytest
         "xmake",
         "premake5",
         "b2",
-        "java",
         "lua",
     ],
 )


### PR DESCRIPTION
Some tools like `pkg-config` can not be removed, because they are largely used in Conan Center, if we remove it, first we need to update ALL recipes in CCI, otherwise, those new images will break many users.

Some tools like vim, used to be installed in the past, for "development" when creating a new recipe. At some point we removed it, and we don't want it again.

closes #287

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
