### PR TITLE
Add MSVC 16

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
       architecture: 'x64'
   - script: |
       pip install -U docker-compose
-      docker-compose ${SERVICE}
+      docker-compose build ${SERVICE}
   strategy:
     matrix:
       MSVC_14:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,15 +10,18 @@ jobs:
       architecture: 'x64'
   - script: |
       pip install -U docker-compose
-      docker-compose build ${SERVICE}
+      docker-compose build %SERVICE%
   strategy:
     matrix:
       MSVC_14:
         SERVICE: "msvc14"
         DOCKER_USERNAME: "conanio"
+        DOCKER_BUILD_TAG: "1.39.0"
       MSVC_15:
         SERVICE: "msvc15"
         DOCKER_USERNAME: "conanio"
+        DOCKER_BUILD_TAG: "1.39.0"
       MSVC_16:
         SERVICE: "msvc16"
         DOCKER_USERNAME: "conanio"
+        DOCKER_BUILD_TAG: "1.39.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: Docker Windows
+- job: Docker_Windows
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 120
@@ -13,12 +13,12 @@ jobs:
       docker-compose ${SERVICE}
   strategy:
     matrix:
-      MSVC 14:
+      MSVC_14:
         SERVICE: "msvc14"
         DOCKER_USERNAME: "conanio"
-      MSVC 15:
+      MSVC_15:
         SERVICE: "msvc15"
         DOCKER_USERNAME: "conanio"
-      MSVC 16:
+      MSVC_16:
         SERVICE: "msvc16"
         DOCKER_USERNAME: "conanio"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
       architecture: 'x64'
   - script: |
       pip install -U docker-compose
-      docker-compose build %SERVICE%
+      docker-compose build --build-arg CONAN_VERSION=1.39.0 %SERVICE%
   strategy:
     matrix:
       MSVC_14:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,90 +1,24 @@
 jobs:
-- job: Docker
+- job: Docker Windows
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.6'
+      versionSpec: '3.7'
       architecture: 'x64'
   - script: |
-      pip install -U docker-compose humanfriendly conan conan-package-tools
-      python build.py
-    env:
-      DOCKER_PASSWORD: $(DOCKER_PASSWORD)
+      pip install -U docker-compose
+      docker-compose ${SERVICE}
   strategy:
     matrix:
-      Ubuntu MinGW GCC 7 x86_64:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "mingw"
-
-      Ubuntu GCC 4.9:
-        GCC_VERSIONS: "4.9"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 5:
-        GCC_VERSIONS: "5"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 6:
-        GCC_VERSIONS: "6"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 7:
-        GCC_VERSIONS: "7"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 8:
-        GCC_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 9:
-        GCC_VERSIONS: "9"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 10:
-        GCC_VERSIONS: "10"
-        DOCKER_ARCHS: "x86_64,armv7,armv7hf"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu GCC 11:
-        GCC_VERSIONS: "11"
-        DOCKER_ARCHS: "x86_64"
-        DOCKER_DISTRO: "jnlp-slave"
-
-      Ubuntu Clang 3.9 x86_64:
-        CLANG_VERSIONS: "3.9"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 4.0 x86_64:
-        CLANG_VERSIONS: "4.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 5.0 x86_64:
-        CLANG_VERSIONS: "5.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 6.0 x86_64:
-        CLANG_VERSIONS: "6.0"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 7 x86_64:
-        CLANG_VERSIONS: "7"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 8 x86_64:
-        CLANG_VERSIONS: "8"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 9 x86_64:
-        CLANG_VERSIONS: "9"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 10 x86_64:
-        CLANG_VERSIONS: "10"
-        DOCKER_DISTRO: "jnlp-slave"
-      Ubuntu Clang 11 x86_64:
-        CLANG_VERSIONS: "11"
-        DOCKER_DISTRO: "jnlp-slave"
-
-      Android Clang 8:
-        DOCKER_CROSS: "android"
-        CLANG_VERSIONS: "8"
-        DOCKER_ARCHS: "x86_64,armv7,armv8"
-
-      Conan Server:
-        BUILD_CONAN_SERVER_IMAGE: 1
+      MSVC 14:
+        SERVICE: "msvc14"
+        DOCKER_USERNAME: "conanio"
+      MSVC 15:
+        SERVICE: "msvc15"
+        DOCKER_USERNAME: "conanio"
+      MSVC 16:
+        SERVICE: "msvc16"
+        DOCKER_USERNAME: "conanio"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -593,6 +593,15 @@ services:
         image: "${DOCKER_USERNAME}/msvc15:${DOCKER_BUILD_TAG}"
         container_name: msvc15
         tty: true
+    msvc16:
+        build:
+            context: msvc_16
+            dockerfile: Dockerfile
+            args:
+                CONAN_VERSION: ${DOCKER_BUILD_TAG}
+        image: "${DOCKER_USERNAME}/msvc16:${DOCKER_BUILD_TAG}"
+        container_name: msvc16
+        tty: true
     android-clang8:
         build:
             context: android-clang_8

--- a/msvc_14/Dockerfile
+++ b/msvc_14/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 

--- a/msvc_14/Dockerfile
+++ b/msvc_14/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -11,10 +11,10 @@ ENV chocolateyUseWindowsCompression=false \
 
 RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
     $env:Path += '";C:\tools\python3;C:\tools\python3\Scripts"'; \
-    choco install --no-progress --yes git --version=2.19.0 --params '"/InstallDir:C:\tools\git"'; \
+    choco install --no-progress --yes git --version=2.32.0.2 --params '"/InstallDir:C:\tools\git"'; \
     choco install --no-progress --yes svn --version=1.8.17 --params '"/InstallDir:C:\tools\svn"'; \
-    choco install --no-progress --yes cmake --version=3.12.2 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
-    choco install --no-progress --yes python3 --version=3.7.0 --params '"/InstallDir:C:\tools\python3"'
+    choco install --no-progress --yes cmake --version=3.21.0 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
+    choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
 
 RUN choco install --no-progress --yes --execution-timeout=0 vcbuildtools --version=2015.4 -ia "/Full"
 

--- a/msvc_14/Dockerfile
+++ b/msvc_14/Dockerfile
@@ -21,7 +21,7 @@ RUN choco install --no-progress --yes --execution-timeout=0 vcbuildtools --versi
 RUN python -m pip install --quiet --upgrade pip; \
     python -m pip install win-unicode-console --quiet --upgrade --force-reinstall --no-cache; \
     python -m pip install conan==${CONAN_VERSION} --quiet --upgrade --force-reinstall --no-cache; \
-    python -m pip install conan_package_tools --quiet --upgrade --force-reinstall --no-cache
+    python -m conan config init
 
 WORKDIR "C:/Users/ContainerAdministrator"
 ENTRYPOINT ["cmd.exe", "C:\\Program Files (x86)\\Microsoft Visual C++ Build Tools\\vcbuildtools_msbuild.bat"]

--- a/msvc_15/Dockerfile
+++ b/msvc_15/Dockerfile
@@ -17,7 +17,7 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
     choco install --no-progress --yes cmake --version=3.21.0 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
     choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
 
-RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
+RUN choco install --no-progress --yes --norestart visualstudio2017buildtools --version=15.9.37.0
 RUN choco install --no-progress --yes visualstudio2017-workload-vctools --version=1.3.3
 RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
 

--- a/msvc_15/Dockerfile
+++ b/msvc_15/Dockerfile
@@ -9,28 +9,32 @@ ARG CONAN_VERSION
 ENV chocolateyUseWindowsCompression=false \
     PYTHONIOENCODING=UTF-8
 
-
 RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
     $env:Path += '";C:\tools\python3;C:\tools\python3\Scripts"';
 
-RUN choco install --no-progress --yes git --version=2.32.0.2 --params '"/InstallDir:C:\tools\git"'; \
-    choco install --no-progress --yes svn --version=1.8.17 --params '"/InstallDir:C:\tools\svn"'; \
-    choco install --no-progress --yes cmake --version=3.21.0 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
-    choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
+RUN choco install --no-progress --yes git --version=2.32.0.2 --params '"/InstallDir:C:\tools\git"'
+RUN choco install --no-progress --yes svn --version=1.8.17 --params '"/InstallDir:C:\tools\svn"'
+RUN choco install --no-progress --yes cmake --version=3.21.0 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'
+RUN choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
 
-RUN choco install --no-progress --yes --ignore-package-exit-codes=3010 dotnetfx --version=4.8.0.20190930
-RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
+RUN choco install --no-progress --yes  --ignore-detected-reboot --ignore-package-exit-codes=3010 dotnetfx --version=4.8.0.20190930
+RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0 --ignore-detected-reboot
 
 # FIXME: visualstudio2017-workload-vctools fails to install. Error code 1
-RUN choco install --yes visualstudio2017-workload-vctools --version=1.3.3 --ignore-detected-reboot --force --ignore-package-exit-codes=1 --use-package-exit-codes=0
+# RUN choco install --yes visualstudio2017-workload-vctools --version=1.3.3 --ignore-detected-reboot --force --ignore-package-exit-codes=1 --use-package-exit-codes=0 || EXIT 0
+RUN if ($(choco install --yes visualstudio2017-workload-vctools --version=1.3.3 --ignore-detected-reboot --force --ignore-package-exit-codes=1 --use-package-exit-codes=0; $null = $null; $?)) { 'success' }
 
 RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
 RUN choco install --no-progress --yes windows-sdk-10.0 --version=10.0.26624
 
-RUN python -m pip install --quiet --upgrade pip; \
-    python -m pip install win-unicode-console --quiet --upgrade --force-reinstall --no-cache; \
-    python -m pip install conan==1.39.0 --quiet --upgrade --force-reinstall --no-cache; \
-    python -m conans.conan config init
+ENV PATH="C:\tools\python3;C:\tools\python3\Scripts;%PATH%"
+
+RUN pip --version
+RUN pip install --quiet --upgrade pip
+RUN pip install win-unicode-console --quiet --upgrade --force-reinstall --no-cache-dir
+RUN pip install conan==1.39.0 --quiet --upgrade --force-reinstall --no-cache-dir
+
+SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
 WORKDIR "C:/Users/ContainerAdministrator"
 ENTRYPOINT ["cmd.exe", "C:\\Program Files (x86)\\Microsoft Visual C++ Build Tools\\vcbuildtools_msbuild.bat"]

--- a/msvc_15/Dockerfile
+++ b/msvc_15/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8
 
 
 LABEL maintainer="Conan.io <info@conan.io>"
@@ -19,7 +19,9 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
 
 RUN choco install --no-progress --yes --ignore-package-exit-codes=3010 dotnetfx --version=4.8.0.20190930
 RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
-RUN choco install --yes --ignore-package-exit-codes=1 visualstudio2017-workload-vctools --version=1.3.3
+
+RUN choco upgrade --yes --no-progress visualstudio2019-workload-vctools
+RUN choco install --yes visualstudio2017-workload-vctools --version=1.3.3
 RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
 RUN choco install --no-progress --yes windows-sdk-10.0 --version=10.0.26624
 

--- a/msvc_15/Dockerfile
+++ b/msvc_15/Dockerfile
@@ -1,5 +1,4 @@
-FROM mcr.microsoft.com/dotnet/framework/sdk:5.0.400-windowsservercore-ltsc2019
-
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 LABEL maintainer="Conan.io <info@conan.io>"
 
@@ -10,9 +9,11 @@ ARG CONAN_VERSION
 ENV chocolateyUseWindowsCompression=false \
     PYTHONIOENCODING=UTF-8
 
+
 RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
-    $env:Path += '";C:\tools\python3;C:\tools\python3\Scripts"'; \
-    choco install --no-progress --yes git --version=2.32.0.2 --params '"/InstallDir:C:\tools\git"'; \
+    $env:Path += '";C:\tools\python3;C:\tools\python3\Scripts"';
+
+RUN choco install --no-progress --yes git --version=2.32.0.2 --params '"/InstallDir:C:\tools\git"'; \
     choco install --no-progress --yes svn --version=1.8.17 --params '"/InstallDir:C:\tools\svn"'; \
     choco install --no-progress --yes cmake --version=3.21.0 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
     choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
@@ -20,14 +21,16 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
 RUN choco install --no-progress --yes --ignore-package-exit-codes=3010 dotnetfx --version=4.8.0.20190930
 RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
 
-RUN choco install --yes visualstudio2017-workload-vctools --version=1.3.3
+# FIXME: visualstudio2017-workload-vctools fails to install. Error code 1
+RUN choco install --yes visualstudio2017-workload-vctools --version=1.3.3 --ignore-detected-reboot --force --ignore-package-exit-codes=1 --use-package-exit-codes=0
+
 RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
 RUN choco install --no-progress --yes windows-sdk-10.0 --version=10.0.26624
 
 RUN python -m pip install --quiet --upgrade pip; \
     python -m pip install win-unicode-console --quiet --upgrade --force-reinstall --no-cache; \
-    python -m pip install conan==${CONAN_VERSION} --quiet --upgrade --force-reinstall --no-cache; \
-    python -m conan config init
+    python -m pip install conan==1.39.0 --quiet --upgrade --force-reinstall --no-cache; \
+    python -m conans.conan config init
 
 WORKDIR "C:/Users/ContainerAdministrator"
 ENTRYPOINT ["cmd.exe", "C:\\Program Files (x86)\\Microsoft Visual C++ Build Tools\\vcbuildtools_msbuild.bat"]

--- a/msvc_15/Dockerfile
+++ b/msvc_15/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8
+FROM mcr.microsoft.com/dotnet/framework/sdk:5.0.400-windowsservercore-ltsc2019
 
 
 LABEL maintainer="Conan.io <info@conan.io>"
@@ -20,7 +20,6 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
 RUN choco install --no-progress --yes --ignore-package-exit-codes=3010 dotnetfx --version=4.8.0.20190930
 RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
 
-RUN choco upgrade --yes --no-progress visualstudio2019-workload-vctools
 RUN choco install --yes visualstudio2017-workload-vctools --version=1.3.3
 RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
 RUN choco install --no-progress --yes windows-sdk-10.0 --version=10.0.26624

--- a/msvc_15/Dockerfile
+++ b/msvc_15/Dockerfile
@@ -1,6 +1,7 @@
-FROM microsoft/windowsservercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+LABEL maintainer="Conan.io <info@conan.io>"
 
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
@@ -11,14 +12,14 @@ ENV chocolateyUseWindowsCompression=false \
 
 RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
     $env:Path += '";C:\tools\python3;C:\tools\python3\Scripts"'; \
-    choco install --no-progress --yes git --version=2.19.0 --params '"/InstallDir:C:\tools\git"'; \
+    choco install --no-progress --yes git --version=2.32.0.2 --params '"/InstallDir:C:\tools\git"'; \
     choco install --no-progress --yes svn --version=1.8.17 --params '"/InstallDir:C:\tools\svn"'; \
-    choco install --no-progress --yes cmake --version=3.12.2 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
-    choco install --no-progress --yes python3 --version=3.7.0 --params '"/InstallDir:C:\tools\python3"'
+    choco install --no-progress --yes cmake --version=3.21.0 --params '"/InstallDir:C:\tools\cmake"' --installargs 'ADD_CMAKE_TO_PATH=""System""'; \
+    choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
 
-RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.2.0
-RUN choco install --no-progress --yes visualstudio2017-workload-vctools --version=1.3.1
-RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.1
+RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
+RUN choco install --no-progress --yes visualstudio2017-workload-vctools --version=1.3.3
+RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
 
 RUN python -m pip install --quiet --upgrade pip; \
     python -m pip install win-unicode-console --quiet --upgrade --force-reinstall --no-cache; \

--- a/msvc_16/.dockerignore
+++ b/msvc_16/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+.idea/
+
+*.md
+*.py
+*.yml
+**/*.sh
+**/*.bat

--- a/msvc_16/Dockerfile
+++ b/msvc_16/Dockerfile
@@ -18,10 +18,10 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
     choco install --no-progress --yes python3 --version=3.7.9 --params '"/InstallDir:C:\tools\python3"'
 
 RUN choco install --no-progress --yes --ignore-package-exit-codes=3010 dotnetfx --version=4.8.0.20190930
-RUN choco install --no-progress --yes visualstudio2017buildtools --version=15.9.37.0
-RUN choco install --yes --ignore-package-exit-codes=1 visualstudio2017-workload-vctools --version=1.3.3
-RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2017-workload-manageddesktop --version=1.2.3
-RUN choco install --no-progress --yes windows-sdk-10.0 --version=10.0.26624
+RUN choco install --no-progress --yes  --ignore-package-exit-codes=-2147024770 visualstudio2019buildtools --version=16.10.4.0
+RUN choco install --yes visualstudio2019-workload-vctools --version=1.0.1
+RUN choco install --no-progress --yes --execution-timeout=0 visualstudio2019-workload-manageddesktop --version=1.0.2
+RUN choco install --no-progress --yes windows-sdk-10.1 --version=10.1.18362.1
 
 RUN python -m pip install --quiet --upgrade pip; \
     python -m pip install win-unicode-console --quiet --upgrade --force-reinstall --no-cache; \

--- a/msvc_16/Dockerfile
+++ b/msvc_16/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8
 
 
 LABEL maintainer="Conan.io <info@conan.io>"


### PR DESCRIPTION
- Add MSVC 16
- Update package versions for MSVC 14 and 15
- Some installation are failing:

```
ERROR: Running ["C:\Users\ContainerAdministrator\AppData\Local\Temp\chocolatey\visualstudio2019buildtools\16.10.4.0\vs_BuildTools.exe" --quiet --norestart --wait] was not successful. Exit code was '-2147024770'. See log for possible error messages.    
The install of visualstudio2019buildtools was NOT successful.                                                                                                                                                                                               
Error while running 'C:\ProgramData\chocolatey\lib\visualstudio2019buildtools\tools\ChocolateyInstall.ps1'.                                                                                                                                                 
 See log for details.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                            
Chocolatey installed 2/3 packages. 1 packages failed.                                                                                                                                                                                                       
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).                                                                                                                                                                                   
                                                                                                                                                                                                                                                            
Failures                                                                                                                                                                                                                                                    
 - visualstudio2019buildtools (exited -2147024770) - Error while running 'C:\ProgramData\chocolatey\lib\visualstudio2019buildtools\tools\ChocolateyInstall.ps1'.                                                                                            
 See log for details.                                                                                                                                                                                                                                       
The command 'powershell.exe -ExecutionPolicy Bypass -Command choco install --no-progress --yes  --ignore-package-exit-codes=-2147024770 visualstudio2019buildtools --version=16.10.4.0' returned a non-zero code: 1                                         
ERROR: Service 'msvc16' failed to build : Build failed                                                                                                                                                                                                      
```


/cc @davidsanfal 
