### PR TITLE
conan config: enable revisions, use libstdc++ by default in gcc

### DIFF
--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -95,7 +95,5 @@ USER conan
 WORKDIR /home/conan
 ENV CONAN_USER_HOME=/home/conan
 
-RUN pip install conan==${CONAN_VERSION}
-RUN conan config set general.revisions_enabled=1
-RUN conan config get general.revisions_enabled
-RUN conan config home
+RUN pip install conan==${CONAN_VERSION} \
+    && conan config set general.revisions_enabled=1

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -95,5 +95,4 @@ USER conan
 WORKDIR /home/conan
 
 RUN pip install conan==${CONAN_VERSION}
-RUN conan config init --force \
-    && conan config set general.revisions_enabled=1
+RUN conan config set general.revisions_enabled=1

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -96,3 +96,5 @@ WORKDIR /home/conan
 
 RUN pip install conan==${CONAN_VERSION}
 RUN conan config set general.revisions_enabled=1
+RUN conan config get general.revisions_enabled=1
+RUN conan config home

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -96,5 +96,5 @@ WORKDIR /home/conan
 
 RUN pip install conan==${CONAN_VERSION}
 RUN conan config set general.revisions_enabled=1
-RUN conan config get general.revisions_enabled=1
+RUN conan config get general.revisions_enabled
 RUN conan config home

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -93,6 +93,7 @@ RUN apt-get -qq update \
 
 USER conan
 WORKDIR /home/conan
+ENV CONAN_USER_HOME=/home/conan
 
 RUN pip install conan==${CONAN_VERSION}
 RUN conan config set general.revisions_enabled=1

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -95,3 +95,4 @@ USER conan
 WORKDIR /home/conan
 
 RUN pip install conan==${CONAN_VERSION}
+RUN conan config set general.revisions_enabled=1

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -95,4 +95,5 @@ USER conan
 WORKDIR /home/conan
 
 RUN pip install conan==${CONAN_VERSION}
-RUN conan config set general.revisions_enabled=1
+RUN conan config init --force \
+    && conan config set general.revisions_enabled=1

--- a/modern/clang/Dockerfile
+++ b/modern/clang/Dockerfile
@@ -155,4 +155,5 @@ RUN sudo mv /tmp/gcc/lib64 /usr/local/ \
     && sudo update-alternatives --install /usr/local/bin/ld ld /usr/local/bin/ld.lld 100 \
     && sudo rm /etc/ld.so.cache \
     && sudo ldconfig -C /etc/ld.so.cache \
-    && conan config init --force
+    && conan config init --force \
+    && conan config set general.revisions_enabled=1

--- a/modern/clang/Dockerfile
+++ b/modern/clang/Dockerfile
@@ -155,5 +155,4 @@ RUN sudo mv /tmp/gcc/lib64 /usr/local/ \
     && sudo update-alternatives --install /usr/local/bin/ld ld /usr/local/bin/ld.lld 100 \
     && sudo rm /etc/ld.so.cache \
     && sudo ldconfig -C /etc/ld.so.cache \
-    && conan config init --force \
-    && conan config set general.revisions_enabled=1
+    && conan profile new --detect --force default

--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -64,6 +64,5 @@ RUN sudo rm -rf /usr/lib/gcc/x86_64-linux-gnu/* \
     && sudo update-alternatives --install /usr/local/bin/c++ c++ /usr/local/bin/g++ 100 \
     && sudo rm /etc/ld.so.cache \
     && sudo ldconfig -C /etc/ld.so.cache \
-    && conan config init --force \
-    && conan profile update settings.compiler.libcxx=libstdc++11 default \
-    && conan config set general.revisions_enabled=1
+    && conan profile new --detect --force default \
+    && conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -64,4 +64,6 @@ RUN sudo rm -rf /usr/lib/gcc/x86_64-linux-gnu/* \
     && sudo update-alternatives --install /usr/local/bin/c++ c++ /usr/local/bin/g++ 100 \
     && sudo rm /etc/ld.so.cache \
     && sudo ldconfig -C /etc/ld.so.cache \
-    && conan config init --force
+    && conan config init --force \
+    && conan profile update settings.compiler.libcxx=libstdc++11 default \
+    && conan config set general.revisions_enabled=1

--- a/modern/tests/test_installed/test_conan.py
+++ b/modern/tests/test_installed/test_conan.py
@@ -2,10 +2,6 @@ def test_conan_version(container, expected):
     out, err = container.exec(['conan', '--version'])
     assert out.strip() == f'Conan version {expected.conan}', f"out: '{out}' err: '{err}'"
 
-def test_home(container):
-    out, err = container.exec(['conan', 'config', 'home'])
-    assert out.strip() == '/home/conan/.conan', f"out: '{out}' err: '{err}'"
-
 def test_revisions_enabled(container):
     out, err = container.exec(['conan', 'config', 'get', 'general.revisions_enabled'])
     assert out.strip() == '1', f"out: '{out}' err: '{err}'"

--- a/modern/tests/test_installed/test_conan.py
+++ b/modern/tests/test_installed/test_conan.py
@@ -3,13 +3,13 @@ def test_conan_version(container, expected):
     assert out.strip() == f'Conan version {expected.conan}', f"out: '{out}' err: '{err}'"
 
 def test_revisions_enabled(container):
-    out, err = container.exec(['conan', 'config', 'get', 'general.revisions_enabled'])
-    assert out.strip() + err.strip() == '1'
+    out, err = container.exec(['conan', 'config', 'get'])
+    assert out.strip() == '1', f"out: '{out}' err: '{err}'"
 
 def test_default_libcxx(container):
     out, err = container.exec(['conan', 'profile', 'show', 'default'])
     if 'compiler=gcc' in out:
-        assert 'compiler.libcxx=libstdc++' in out
+        assert 'compiler.libcxx=libstdc++' in out, f"out: '{out}' err: '{err}'"
 
 # TODO: Add more tests here:
 #   * default profiles exists, and it has proper libcxx value

--- a/modern/tests/test_installed/test_conan.py
+++ b/modern/tests/test_installed/test_conan.py
@@ -2,6 +2,15 @@ def test_conan_version(container, expected):
     out, err = container.exec(['conan', '--version'])
     assert out.strip() == f'Conan version {expected.conan}', f"out: '{out}' err: '{err}'"
 
+def test_revisions_enabled(container):
+    out, err = container.exec(['conan', 'config', 'get', 'general.revisions_enabled'])
+    assert out.strip() == '1'
+
+def test_default_libcxx(container):
+    out, err = container.exec(['conan', 'profile', 'show', 'default'])
+    if 'compiler=gcc' in out:
+        assert 'compiler.libcxx=libstdc++' in out
+
 # TODO: Add more tests here:
 #   * default profiles exists, and it has proper libcxx value
 #   * python version used by Conan

--- a/modern/tests/test_installed/test_conan.py
+++ b/modern/tests/test_installed/test_conan.py
@@ -4,7 +4,7 @@ def test_conan_version(container, expected):
 
 def test_revisions_enabled(container):
     out, err = container.exec(['conan', 'config', 'get', 'general.revisions_enabled'])
-    assert out.strip() == '1'
+    assert out.strip() + err.strip() == '1'
 
 def test_default_libcxx(container):
     out, err = container.exec(['conan', 'profile', 'show', 'default'])

--- a/modern/tests/test_installed/test_conan.py
+++ b/modern/tests/test_installed/test_conan.py
@@ -2,8 +2,12 @@ def test_conan_version(container, expected):
     out, err = container.exec(['conan', '--version'])
     assert out.strip() == f'Conan version {expected.conan}', f"out: '{out}' err: '{err}'"
 
-def test_revisions_enabled(container):
+def test_home(container):
     out, err = container.exec(['conan', 'config', 'home'])
+    assert out.strip() == '/home/conan/.conan', f"out: '{out}' err: '{err}'"
+
+def test_revisions_enabled(container):
+    out, err = container.exec(['conan', 'config', 'get', 'general.revisions_enabled'])
     assert out.strip() == '1', f"out: '{out}' err: '{err}'"
 
 def test_default_libcxx(container):

--- a/modern/tests/test_installed/test_conan.py
+++ b/modern/tests/test_installed/test_conan.py
@@ -3,7 +3,7 @@ def test_conan_version(container, expected):
     assert out.strip() == f'Conan version {expected.conan}', f"out: '{out}' err: '{err}'"
 
 def test_revisions_enabled(container):
-    out, err = container.exec(['conan', 'config', 'get'])
+    out, err = container.exec(['conan', 'config', 'home'])
     assert out.strip() == '1', f"out: '{out}' err: '{err}'"
 
 def test_default_libcxx(container):


### PR DESCRIPTION
IMO, it would be useful to use the defaults that are aligned with the future.

Closes https://github.com/conan-io/conan-docker-tools/issues/304