### PR TITLE
Fix certificate error for old GCC images 4.8 and 4.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,14 @@ jobs:
         DOCKER_DISTRO: "mingw"
         CDT_SKIP_TEST: "TRUE"
 
+      Ubuntu GCC 4.8:
+        GCC_VERSIONS: "4.8"
+        DOCKER_ARCHS: "x86_64"
+
+      Ubuntu GCC 4.9:
+        GCC_VERSIONS: "4.9"
+        DOCKER_ARCHS: "x86_64"
+
       Ubuntu GCC 5:
         GCC_VERSIONS: "5"
         DOCKER_ARCHS: "x86_64,armv7,armv7hf,armv8"

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -60,8 +60,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && pyenv install -v 3.6.7 \
-    && pyenv global 3.6.7 \
+    && pyenv install -v 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.8-x86/Dockerfile
+++ b/gcc_4.8-x86/Dockerfile
@@ -62,8 +62,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
-    && pyenv global 3.6.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -63,7 +63,7 @@ RUN dpkg --add-architecture i386 \
     && tar -xzf openssl-1.1.1l.tar.gz \
     && cd openssl-1.1.1l \
     && ./config no-unit-test shared \
-    && make -S \
+    && make -s \
     && make install_sw \
     && rm -rf openssl-* \
     && ln -sf /usr/local/bin/openssl /usr/bin/openssl \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -60,10 +60,10 @@ RUN dpkg --add-architecture i386 \
     && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
     && rm /etc/ssl/certs/DST_Root_CA_X3.pem \
     && wget -q --no-check-certificate https://www.openssl.org/source/openssl-1.1.1l.tar.gz \
-    && tar -xvzf openssl-1.1.1l.tar.gz \
+    && tar -xzf openssl-1.1.1l.tar.gz \
     && cd openssl-1.1.1l \
     && ./config no-unit-test shared \
-    && make \
+    && make -S \
     && make install_sw \
     && rm -rf openssl-* \
     && ln -sf /usr/local/bin/openssl /usr/bin/openssl \

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -58,13 +58,23 @@ RUN dpkg --add-architecture i386 \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
     && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
+    && rm /etc/ssl/certs/DST_Root_CA_X3.pem \
+    && wget -q --no-check-certificate https://www.openssl.org/source/openssl-1.1.1l.tar.gz \
+    && tar -xvzf openssl-1.1.1l.tar.gz \
+    && cd openssl-1.1.1l \
+    && ./config no-unit-test shared \
+    && make \
+    && make install_sw \
+    && rm -rf openssl-* \
+    && ln -sf /usr/local/bin/openssl /usr/bin/openssl \
+    && ldconfig \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
-    && pyenv global 3.6.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib pyenv install 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.9-armv7/Dockerfile
+++ b/gcc_4.9-armv7/Dockerfile
@@ -60,8 +60,8 @@ RUN apt-get -qq update \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
-    && pyenv global 3.6.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.9-armv7hf/Dockerfile
+++ b/gcc_4.9-armv7hf/Dockerfile
@@ -62,8 +62,8 @@ RUN dpkg --add-architecture armhf \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
-    && pyenv global 3.6.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.9-x86/Dockerfile
+++ b/gcc_4.9-x86/Dockerfile
@@ -69,8 +69,8 @@ RUN dpkg --add-architecture i386 \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
-    && pyenv global 3.6.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -69,13 +69,23 @@ RUN dpkg --add-architecture i386 \
     && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
     && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
+    && rm /etc/ssl/certs/DST_Root_CA_X3.pem \
+    && wget -q --no-check-certificate https://www.openssl.org/source/openssl-1.1.1l.tar.gz \
+    && tar -xvzf openssl-1.1.1l.tar.gz \
+    && cd openssl-1.1.1l \
+    && ./config no-unit-test shared \
+    && make \
+    && make install_sw \
+    && rm -rf openssl-* \
+    && ln -sf /usr/local/bin/openssl /usr/bin/openssl \
+    && ldconfig \
     && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
-    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.7 \
-    && pyenv global 3.6.7 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib pyenv install 3.6.15 \
+    && pyenv global 3.6.15 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -71,10 +71,10 @@ RUN dpkg --add-architecture i386 \
     && sed -i '0,/python3/s//python/' /usr/bin/lsb_release \
     && rm /etc/ssl/certs/DST_Root_CA_X3.pem \
     && wget -q --no-check-certificate https://www.openssl.org/source/openssl-1.1.1l.tar.gz \
-    && tar -xvzf openssl-1.1.1l.tar.gz \
+    && tar -xzf openssl-1.1.1l.tar.gz \
     && cd openssl-1.1.1l \
     && ./config no-unit-test shared \
-    && make \
+    && make -S \
     && make install_sw \
     && rm -rf openssl-* \
     && ln -sf /usr/local/bin/openssl /usr/bin/openssl \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -74,7 +74,7 @@ RUN dpkg --add-architecture i386 \
     && tar -xzf openssl-1.1.1l.tar.gz \
     && cd openssl-1.1.1l \
     && ./config no-unit-test shared \
-    && make -S \
+    && make -s \
     && make install_sw \
     && rm -rf openssl-* \
     && ln -sf /usr/local/bin/openssl /usr/bin/openssl \


### PR DESCRIPTION
Changelog: Bugfix: Fix certificate error for old gcc images 4.8 and 4.9

The OpenSSL version installed for Ubuntu Trusty is old (1.0.2) and can not be used with new certificates.

Related to https://github.com/conan-io/conan/issues/9695

Thus, this PR:

- Remove DST_Root_CA_X3.pem 
- Bump Python 3.6.7 to 3.6.15 for old images
- Install and build OpenSSL 1.1.1l

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
