### PR TITLE
Fix lsb_release command

### DIFF
--- a/build.py
+++ b/build.py
@@ -235,8 +235,12 @@ class ConanDockerTools(object):
         subprocess.check_call("docker run -t -d --name %s %s" % (self.service,
             self.created_image_name), shell=True)
 
-        for sudo_command in sudo_commands:
+        try:
+            subprocess.check_call(["lsb_release"])
+        except FileNotFoundError:
+            pass
 
+        for sudo_command in sudo_commands:
             logging.info("Testing command prefix: '{}'".format(sudo_command))
             output = subprocess.check_output(
                 "docker exec %s %s python3 --version" % (self.service, sudo_command), shell=True)

--- a/clang_7/Dockerfile
+++ b/clang_7/Dockerfile
@@ -88,6 +88,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_8/Dockerfile
+++ b/clang_8/Dockerfile
@@ -86,6 +86,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/clang_9/Dockerfile
+++ b/clang_9/Dockerfile
@@ -90,6 +90,7 @@ RUN dpkg --add-architecture i386 \
     && pyenv global 3.7.5 \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \

--- a/gcc_10/Dockerfile
+++ b/gcc_10/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get -qq update \
     && pyenv global ${PYTHON_VERSION} \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools cmake==${CMAKE_VERSION_FULL} \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && chown -R conan:1001 /opt/pyenv \
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \

--- a/gcc_11/Dockerfile
+++ b/gcc_11/Dockerfile
@@ -72,6 +72,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan conan-package-tools cmake==${CMAKE_VERSION_FULL} \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -86,6 +86,8 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib pyenv install 3.6.15 \
     && pyenv global 3.6.15 \
+    && sed -e 's/! \/usr/!\/usr\/local/g' -i /usr/bin/lsb_release \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.6.15/lib/python3.6/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_5/Dockerfile
+++ b/gcc_5/Dockerfile
@@ -73,6 +73,7 @@ RUN dpkg --add-architecture i386 \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
        && pyenv global 3.7.5 \
+       && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
        && pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \

--- a/gcc_6/Dockerfile
+++ b/gcc_6/Dockerfile
@@ -81,6 +81,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_7/Dockerfile
+++ b/gcc_7/Dockerfile
@@ -79,6 +79,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_8/Dockerfile
+++ b/gcc_8/Dockerfile
@@ -79,6 +79,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \

--- a/gcc_9/Dockerfile
+++ b/gcc_9/Dockerfile
@@ -81,6 +81,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
     && pyenv global 3.7.5 \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.5/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \


### PR DESCRIPTION
The `lsb_release` command is hardcoded to use system's python, not the installed pyenv. Also, the module `lsb_release.py` is not available as python package, only from apt, so the recommended way is creating a link to find the module from system.

fixes #364

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
