### PR TITLE
Accept Conan version as env var

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,7 +13,7 @@ from cpt.ci_manager import CIManager
 from cpt.printer import Printer
 
 
-TARGET_CONAN_VERSION = "1.43.3"
+TARGET_CONAN_VERSION = os.getenv("CONAN_VERSION", "1.44.1")
 
 
 class ConanDockerTools(object):


### PR DESCRIPTION
- Update legacy images to 1.44.1
- Support CONAN_VERSION as environment variable, so we can re-run CI without new commit.

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
