### PR TITLE
Skip azure when updating modern images

### DIFF
--- a/.ci/on_conan_release.jenkinsfile
+++ b/.ci/on_conan_release.jenkinsfile
@@ -50,7 +50,7 @@ node('Linux') {
 
             sh 'git config --local user.email "javierg@jfrog.com"'
             sh 'git config --local user.name "Release Bot"'
-            sh 'git commit -am "[up conan] Update Conan version"'
+            sh 'git commit -am "[up conan] [azp skip] Update Conan version"'
 
             if (params.build_old_images) {
                 withCredentials([usernamePassword(credentialsId: 'conanci-gh-token', usernameVariable: 'GH_USER', passwordVariable: 'GH_PASS')]) {
@@ -63,7 +63,7 @@ node('Linux') {
         // Open PR in Github
         stage('Open PR in Github') {
             def data = readJSON text: '{}'
-            data.title = "[up conan] Update Conan version (${params.conan_version})" as String
+            data.title = "[up conan] [azp skip] Update Conan version (${params.conan_version})" as String
             data.head = branchName
             data.base = 'master' as String
             data.body = '''\


### PR DESCRIPTION
Modern images are automatically updated by Jenkins, but legacy images don't. This PR skips Azure when updating modern images.

We can think about update legacy images later, let's fix this inconvenient first.

Detailed information how to skip Azure jobs: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#skipping-ci-for-individual-pushes

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
