### PR TITLE
Fix .env path for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 | Service | OS |  Status  |
 |---------|----|----------|
-| Azure | Windows | [![Azure Status](https://dev.azure.com/conanio/conan-docker-tools/_apis/build/status/conan-io.conan-docker-tools?branchName=master)](https://dev.azure.com/conanio/conan-docker-tools/_build/latest?definitionId=1&branchName=master) |
-| Jenkins | Linux | [[![Build Status](https://ci.conan.io/buildStatus/icon?job=ConanDockerTools%2FXenial%2Fmaster)](https://ci.conan.io/job/ConanDockerTools/job/Xenial/job/master/) |
+| Jenkins | Linux | [![Build Status](https://ci.conan.io/buildStatus/icon?job=ConanDockerTools%2FXenial%2Fmaster)](https://ci.conan.io/job/ConanDockerTools/job/Xenial/job/master/) |
 
 > :warning: **Warning:**
 Current images will be superseeded by the ones in [`modern`](./modern) folder,

--- a/modern/tests/fixtures/expected.py
+++ b/modern/tests/fixtures/expected.py
@@ -70,7 +70,7 @@ def get_compiler_versions():
 
 
 def get_envfile_values():
-    envfile = os.path.join(os.path.dirname(__file__), '..', '..', '.env')
+    envfile = os.path.join(os.path.dirname(__file__), '..', '..', '..', '.env')
     env_values = {}
     with open(envfile, 'r') as f:
         for line in f:


### PR DESCRIPTION
- Modern tests use relative path to read .env file. Needed a hotfix
- Removed Azure badge from readme file

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
