### PR TITLE
Allow to use Ubuntu 18.04 as a base image

### DIFF
--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
     && update-alternatives --install /usr/local/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/local/bin/pip pip /opt/pyenv/shims/pip 100 \
-    && ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/site-packages/lsb_release.py \
+    && ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/${PYTHON_VERSION}/lib/python${PYTHON_VERSION%.*}/site-packages/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && printf '/usr/local/lib\n' > /etc/ld.so.conf.d/20local-lib.conf \
     && printf '/usr/local/lib64\n' >> /etc/ld.so.conf.d/20local-lib.conf \

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get -qq update \
     && mv /etc/ld.so.conf.d/libc.conf /etc/ld.so.conf.d/10libc.conf \
     && rm /etc/ld.so.cache \
     && ldconfig -C /etc/ld.so.cache \
-    && apt-get -qq purge -y g++-multilib gcc gcc-5 \
+    && apt-get -qq purge -y g++-multilib gcc \
     && apt-get -qq autoremove -y \
     && apt-get -qq autoclean \
     && apt-get -qq update \

--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -qq update \
        gcc \
        curl \
        wget \
-       zlib1g \
+       zlib1g-dev \
        ca-certificates \
        autoconf-archive \
        binutils \


### PR DESCRIPTION
Changelog: (Feature): Allow to use Ubuntu 18.04 as a base image

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
