### PR TITLE
Do not override cpp and c++ installation 

### DIFF
--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -61,7 +61,7 @@ RUN sudo rm -rf /usr/lib/gcc/x86_64-linux-gnu/* \
     && sudo cp -a /tmp/install/bin/* /usr/local/bin/ \
     && sudo rm -rf /tmp/install \
     && sudo update-alternatives --install /usr/local/bin/cc cc /usr/local/bin/gcc 100 \
-    && sudo update-alternatives --install /usr/local/bin/cpp cpp /usr/local/bin/g++ 100 \
+    && sudo update-alternatives --install /usr/local/bin/cpp cpp /usr/local/bin/cpp 100 \
     && sudo update-alternatives --install /usr/local/bin/c++ c++ /usr/local/bin/g++ 100 \
     && sudo rm /etc/ld.so.cache \
     && sudo ldconfig -C /etc/ld.so.cache \

--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -61,8 +61,6 @@ RUN sudo rm -rf /usr/lib/gcc/x86_64-linux-gnu/* \
     && sudo cp -a /tmp/install/bin/* /usr/local/bin/ \
     && sudo rm -rf /tmp/install \
     && sudo update-alternatives --install /usr/local/bin/cc cc /usr/local/bin/gcc 100 \
-    && sudo update-alternatives --install /usr/local/bin/cpp cpp /usr/local/bin/cpp 100 \
-    && sudo update-alternatives --install /usr/local/bin/c++ c++ /usr/local/bin/g++ 100 \
     && sudo rm /etc/ld.so.cache \
     && sudo ldconfig -C /etc/ld.so.cache \
     && conan profile new --detect --force default \

--- a/modern/tests/test_installed/test_gcc.py
+++ b/modern/tests/test_installed/test_gcc.py
@@ -5,10 +5,11 @@ import pytest
 @pytest.mark.service('deploy', 'jenkins')
 class TestGccCompiler:
 
-    def test_version(self, container, expected):
-        out, _ = container.exec(['gcc', '--version'])
+    @pytest.mark.parametrize('app', ['gcc', 'cc', 'cpp', 'c++', 'g++'])
+    def test_version(self, container, expected, app):
+        out, _ = container.exec([app, '--version'])
         first_line = out.splitlines()[0]
-        assert first_line.strip() == f'gcc (GCC) {expected.compiler.version}'
+        assert first_line.strip() == f'{app} (GCC) {expected.compiler.version}'
 
     def test_gfortran_version(self, container, expected):
         out, _ = container.exec(['gfortran', '--version'])


### PR DESCRIPTION
fixes https://github.com/conan-io/conan-docker-tools/issues/405

No more errors when building imake:

```
conan@6a163f810cb0:~$ conan install imake/1.0.8@ --build=imake --profile:host=default --profile:build=default                
Configuration (profile_host):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

Configuration (profile_build):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

imake/1.0.8: Forced build from source
Installing package: imake/1.0.8
Requirements
    imake/1.0.8 from 'conancenter' - Cache
    xorg-macros/1.19.3 from 'conancenter' - Cache
    xorg-proto/2021.4 from 'conancenter' - Cache
Packages
    imake/1.0.8:6d79074e6b74d1f982335ed1af699b2b4573ebad - Build
    xorg-macros/1.19.3:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache
    xorg-proto/2021.4:d77b3eb875feeddc23326a754ee7148151296cfe - Cache
Build requirements
    autoconf/2.71 from 'conancenter' - Cache
    automake/1.16.3 from 'conancenter' - Cache
    m4/1.4.19 from 'conancenter' - Cache
    pkgconf/1.7.4 from 'conancenter' - Cache
Build requirements packages
    autoconf/2.71:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache
    automake/1.16.3:258f6f05ca54813b3d7180161753df7f9ccf7e1d - Cache
    m4/1.4.19:24647d9fe8ec489125dfbae4b3ebefaf7581674c - Cache
    pkgconf/1.7.4:dfbe50feef7f3c6223a476cd5aeadb687084a646 - Cache

Installing (downloading, building) binaries...
m4/1.4.19: Already installed!
m4/1.4.19: Appending PATH environment variable: /home/conan/.conan/data/m4/1.4.19/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin
m4/1.4.19: Setting M4 environment variable: /home/conan/.conan/data/m4/1.4.19/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/m4
pkgconf/1.7.4: Already installed!
pkgconf/1.7.4: Appending PATH env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/dfbe50feef7f3c6223a476cd5aeadb687084a646/bin
pkgconf/1.7.4: Setting PKG_CONFIG env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/dfbe50feef7f3c6223a476cd5aeadb687084a646/bin/pkgconf
pkgconf/1.7.4: Appending AUTOMAKE_CONAN_INCLUDES env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/dfbe50feef7f3c6223a476cd5aeadb687084a646/bin/aclocal
xorg-macros/1.19.3: Already installed!
xorg-macros/1.19.3: Appending AUTOMAKE_CONAN_INCLUDES environment variable: /home/conan/.conan/data/xorg-macros/1.19.3/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/share/aclocal
autoconf/2.71: Already installed!
autoconf/2.71: Appending PATH env var with : /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin
autoconf/2.71: Setting AC_MACRODIR to /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/share/autoconf
autoconf/2.71: Setting AUTOCONF to /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autoconf
autoconf/2.71: Setting AUTORECONF to /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autoreconf
autoconf/2.71: Setting AUTOHEADER to /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autoheader
autoconf/2.71: Setting AUTOM4TE to /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autom4te
autoconf/2.71: Setting AUTOM4TE_PERLLIBDIR to /home/conan/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/share/autoconf
xorg-proto/2021.4: Already installed!
automake/1.16.3: Already installed!
automake/1.16.3: Appending PATH environment variable:: /home/conan/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/bin
automake/1.16.3: Appending ACLOCAL environment variable with: /home/conan/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/bin/aclocal
automake/1.16.3: Setting AUTOMAKE_DATADIR to /home/conan/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/res
automake/1.16.3: Setting AUTOMAKE_LIBDIR to /home/conan/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/res/automake-1.16
automake/1.16.3: Setting AUTOMAKE_PERLLIBDIR to /home/conan/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/res/automake-1.16
automake/1.16.3: Setting AUTOMAKE to /home/conan/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/bin/automake
automake/1.16.3: Append M4 include directories to AUTOMAKE_CONAN_INCLUDES environment variable
imake/1.0.8: Applying build-requirement: automake/1.16.3
imake/1.0.8: Applying build-requirement: pkgconf/1.7.4
imake/1.0.8: Applying build-requirement: autoconf/2.71
imake/1.0.8: Applying build-requirement: m4/1.4.19
imake/1.0.8: Copying sources to build folder
imake/1.0.8: Building your package in /home/conan/.conan/data/imake/1.0.8/_/_/build/6d79074e6b74d1f982335ed1af699b2b4573ebad
imake/1.0.8: Generator pkg_config created xproto.pc
imake/1.0.8: Generator pkg_config created xineramaproto.pc
imake/1.0.8: Generator pkg_config created xf86vidmodeproto.pc
imake/1.0.8: Generator pkg_config created xf86driproto.pc
imake/1.0.8: Generator pkg_config created xf86dgaproto.pc
imake/1.0.8: Generator pkg_config created xf86bigfontproto.pc
imake/1.0.8: Generator pkg_config created xextproto.pc
imake/1.0.8: Generator pkg_config created xcmiscproto.pc
imake/1.0.8: Generator pkg_config created videoproto.pc
imake/1.0.8: Generator pkg_config created scrnsaverproto.pc
imake/1.0.8: Generator pkg_config created resourceproto.pc
imake/1.0.8: Generator pkg_config created renderproto.pc
imake/1.0.8: Generator pkg_config created recordproto.pc
imake/1.0.8: Generator pkg_config created randrproto.pc
imake/1.0.8: Generator pkg_config created presentproto.pc
imake/1.0.8: Generator pkg_config created kbproto.pc
imake/1.0.8: Generator pkg_config created inputproto.pc
imake/1.0.8: Generator pkg_config created glproto.pc
imake/1.0.8: Generator pkg_config created fontsproto.pc
imake/1.0.8: Generator pkg_config created fixesproto.pc
imake/1.0.8: Generator pkg_config created dri3proto.pc
imake/1.0.8: Generator pkg_config created dri2proto.pc
imake/1.0.8: Generator pkg_config created dpmsproto.pc
imake/1.0.8: Generator pkg_config created dmxproto.pc
imake/1.0.8: Generator pkg_config created damageproto.pc
imake/1.0.8: Generator pkg_config created compositeproto.pc
imake/1.0.8: Generator pkg_config created bigreqsproto.pc
imake/1.0.8: Generator pkg_config created applewmproto.pc
imake/1.0.8: Generator pkg_config created xorg-proto.pc
imake/1.0.8: Generator pkg_config created xorg-macros.pc
imake/1.0.8: Aggregating env generators
imake/1.0.8: Calling build()
imake/1.0.8: Calling:
 > source_subfolder/configure '--enable-ccmakedep=yes' '--enable-cleanlinks=yes' '--enable-makeg=yes' '--enable-mergelib=yes' '--enable-mkdirhier=yes' '--enable-mkhtmlindex=yes' '--enable-revpath=yes' '--enable-xmkmf=yes' '--prefix=/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libexecdir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/share' 
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking for style of include used by make... GNU
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for gcc option to accept ISO C99... none needed
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking whether __clang__ is declared... no
checking whether __INTEL_COMPILER is declared... no
checking whether __SUNPRO_C is declared... no
checking pkg-config is at least version 0.9.0... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for a sed that does not truncate output... /bin/sed
checking if gcc supports -Werror=unknown-warning-option... no
checking if gcc supports -Werror=unused-command-line-argument... no
checking if gcc supports -Wall... yes
checking if gcc supports -Wpointer-arith... yes
checking if gcc supports -Wmissing-declarations... yes
checking if gcc supports -Wformat=2... yes
checking if gcc supports -Wstrict-prototypes... yes
checking if gcc supports -Wmissing-prototypes... yes
checking if gcc supports -Wnested-externs... yes
checking if gcc supports -Wbad-function-cast... yes
checking if gcc supports -Wold-style-definition... yes
checking if gcc supports -Wdeclaration-after-statement... yes
checking if gcc supports -Wunused... yes
checking if gcc supports -Wuninitialized... yes
checking if gcc supports -Wshadow... yes
checking if gcc supports -Wmissing-noreturn... yes
checking if gcc supports -Wmissing-format-attribute... yes
checking if gcc supports -Wredundant-decls... yes
checking if gcc supports -Wlogical-op... yes
checking if gcc supports -Werror=implicit... yes
checking if gcc supports -Werror=nonnull... yes
checking if gcc supports -Werror=init-self... yes
checking if gcc supports -Werror=main... yes
checking if gcc supports -Werror=missing-braces... yes
checking if gcc supports -Werror=sequence-point... yes
checking if gcc supports -Werror=return-type... yes
checking if gcc supports -Werror=trigraphs... yes
checking if gcc supports -Werror=array-bounds... yes
checking if gcc supports -Werror=write-strings... yes
checking if gcc supports -Werror=address... yes
checking if gcc supports -Werror=int-to-pointer-cast... yes
checking if gcc supports -Werror=pointer-to-int-cast... yes
checking if gcc supports -pedantic... yes
checking if gcc supports -Werror... yes
checking if gcc supports -Werror=attributes... yes
checking whether make supports nested variables... (cached) yes
checking how to run the C preprocessor... gcc -E
checking for cpp... /usr/local/bin/cpp
checking if /usr/local/bin/cpp requires -undef... yes
checking if /usr/local/bin/cpp requires -traditional... yes
checking for mkstemp... yes
checking for perl... yes
checking for XPROTO... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating config.h
config.status: executing depfiles commands
make  all-am
make[1]: Entering directory '/home/conan/.conan/data/imake/1.0.8/_/_/build/6d79074e6b74d1f982335ed1af699b2b4573ebad'
gcc -DHAVE_CONFIG_H -I. -Isource_subfolder   -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include/X11 -DNDEBUG -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include/X11  -DCPP_PROGRAM='"/usr/local/bin/cpp"' -Wall -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wdeclaration-after-statement -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -m64 -O3 -s -MT imake-imake.o -MD -MP -MF .deps/imake-imake.Tpo -c -o imake-imake.o `test -f 'imake.c' || echo 'source_subfolder/'`imake.c
gcc -DHAVE_CONFIG_H -I. -Isource_subfolder   -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include/X11 -DNDEBUG -Wall -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wdeclaration-after-statement -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -m64 -O3 -s -MT revpath.o -MD -MP -MF .deps/revpath.Tpo -c -o revpath.o source_subfolder/revpath.c
/usr/local/bin/cpp -undef -traditional -DCONFIGDIRSPEC='"-I/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/lib/X11/config"' source_subfolder/xmkmf.cpp | /bin/sed -e /^\#/d | /bin/sed -e s/XCOMM/\#/ > xmkmf
/usr/local/bin/cpp -undef -traditional -DPREPROC='"gcc -E"' source_subfolder/mdepend.cpp | /bin/sed -e /^\#/d | /bin/sed -e s/XCOMM/\#/ > ccmakedep
source_subfolder/mdepend.cpp:198:9: warning: missing terminating ' character
  198 |   | awk '{
      |         ^
source_subfolder/mdepend.cpp:236:28: warning: missing terminating ' character
  236 |   | egrep -v '^[^:]*:[  ]*$' >> $DEPENDLINES
      |                            ^
/usr/local/bin/cpp -undef -traditional -DARCMD="ar clq" -DRANLIB="ranlib" source_subfolder/mergelib.cpp | /bin/sed -e /^\#/d | /bin/sed -e s/XCOMM/\#/ > mergelib
cp source_subfolder/mkhtmlindex.pl mkhtmlindex
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/imake.man > imake.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/revpath.man > revpath.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/makeg.man > makeg.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/xmkmf.man > xmkmf.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/ccmakedep.man > ccmakedep.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/mergelib.man > mergelib.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/mkdirhier.man > mkdirhier.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/cleanlinks.man > cleanlinks.1
/bin/sed -e 's|__vendorversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xorgversion__|"imake 1.0.8" "X Version 11"|' 	-e 's|__xservername__|Xorg|g' 	-e 's|__xconfigfile__|xorg.conf|g' 	-e 's|__projectroot__|/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad|g' 	-e 's|__apploaddir__||g' 	-e 's|__appmansuffix__|1|g' 	-e 's|__drivermansuffix__|4|g' 	-e 's|__adminmansuffix__|8|g' 	-e 's|__libmansuffix__|3|g' 	-e 's|__miscmansuffix__|7|g' 	-e 's|__filemansuffix__|5|g' -e 's|__cpp__|/usr/local/bin/cpp|g' < source_subfolder/mkhtmlindex.man > mkhtmlindex.1
source_subfolder/imake.c: In function ‘FindImakefile’:
source_subfolder/imake.c:667:27: warning: declaration of ‘Imakefile’ shadows a global declaration [-Wshadow]
  667 | FindImakefile(const char *Imakefile)
      |               ~~~~~~~~~~~~^~~~~~~~~
source_subfolder/imake.c:324:18: note: shadowed declaration is here
  324 | const char      *Imakefile = NULL;
      |                  ^~~~~~~~~
source_subfolder/imake.c: In function ‘doit’:
source_subfolder/imake.c:811:29: warning: passing argument 2 of ‘execvp’ from incompatible pointer type [-Wincompatible-pointer-types]
  811 |                 execvp(cmd, argv);
      |                             ^~~~
      |                             |
      |                             const char **
In file included from source_subfolder/imake.c:169:
/usr/include/unistd.h:581:52: note: expected ‘char * const*’ but argument is of type ‘const char **’
  581 | extern int execvp (const char *__file, char *const __argv[])
      |                                        ~~~~~~~~~~~~^~~~~~~~
source_subfolder/imake.c: In function ‘parse_utsname’:
source_subfolder/imake.c:826:7: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  826 |       LogFatal(msg,fmt);
      |       ^~~~~~~~
source_subfolder/imake.c:833:9: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  833 |         LogFatal(msg, fmt);
      |         ^~~~~~~~
source_subfolder/imake.c:873:11: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  873 |           LogFatal(msg, fmt);
      |           ^~~~~~~~
source_subfolder/imake.c:883:3: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  883 |   (void) sscanf(buf, fmt + arg + 1, result);
      |   ^
source_subfolder/imake.c: In function ‘get_libc_version’:
source_subfolder/imake.c:994:8: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  994 |     cc = "gcc";
      |        ^
source_subfolder/imake.c:1000:3: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
 1000 |   if (snprintf (command , len, format, cc, aout) == len)
      |   ^~
source_subfolder/imake.c: In function ‘define_os_defaults’:
source_subfolder/imake.c:1641:16: warning: declaration of ‘name’ shadows a previous local [-Wshadow]
 1641 |           char name[PATH_MAX];
      |                ^~~~
source_subfolder/imake.c:1435:25: note: shadowed declaration is here
 1435 |         struct utsname *name = NULL;
      |                         ^~~~
mv -f .deps/revpath.Tpo .deps/revpath.Po
gcc -Wall -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wdeclaration-after-statement -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -m64 -O3 -s  -m64 -o revpath revpath.o  
mv -f .deps/imake-imake.Tpo .deps/imake-imake.Po
gcc -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include -I/home/conan/.conan/data/xorg-proto/2021.4/_/_/package/d77b3eb875feeddc23326a754ee7148151296cfe/include/X11  -DCPP_PROGRAM='"/usr/local/bin/cpp"' -Wall -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wdeclaration-after-statement -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -m64 -O3 -s  -m64 -o imake imake-imake.o  
make[1]: Leaving directory '/home/conan/.conan/data/imake/1.0.8/_/_/build/6d79074e6b74d1f982335ed1af699b2b4573ebad'
imake/1.0.8: Package '6d79074e6b74d1f982335ed1af699b2b4573ebad' built
imake/1.0.8: Build folder /home/conan/.conan/data/imake/1.0.8/_/_/build/6d79074e6b74d1f982335ed1af699b2b4573ebad
imake/1.0.8: Generated conaninfo.txt
imake/1.0.8: Generated conanbuildinfo.txt
imake/1.0.8: Generating the package
imake/1.0.8: Package folder /home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad
imake/1.0.8: Calling package()
make[1]: Entering directory '/home/conan/.conan/data/imake/1.0.8/_/_/build/6d79074e6b74d1f982335ed1af699b2b4573ebad'
 /bin/mkdir -p '/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/bin'
 /bin/mkdir -p '/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/share/man/man1'
 /bin/mkdir -p '/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/bin'
 /usr/bin/install -c source_subfolder/makeg xmkmf ccmakedep mergelib source_subfolder/mkdirhier source_subfolder/cleanlinks mkhtmlindex '/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/bin'
 /usr/bin/install -c -m 644 imake.1 revpath.1 makeg.1 xmkmf.1 ccmakedep.1 mergelib.1 mkdirhier.1 cleanlinks.1 mkhtmlindex.1 '/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/share/man/man1'
  /usr/bin/install -c imake revpath '/home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/bin'
make[1]: Leaving directory '/home/conan/.conan/data/imake/1.0.8/_/_/build/6d79074e6b74d1f982335ed1af699b2b4573ebad'
imake/1.0.8 package(): Packaged 10 files
imake/1.0.8: Package '6d79074e6b74d1f982335ed1af699b2b4573ebad' created
imake/1.0.8: Created package revision f96224d6db685aae23c46cd46256363b
imake/1.0.8: Appending PATH environment variable: /home/conan/.conan/data/imake/1.0.8/_/_/package/6d79074e6b74d1f982335ed1af699b2b4573ebad/bin
Aggregating env generators
```

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
