### PR TITLE
Use named group

### DIFF
--- a/legacy/clang_10/Dockerfile
+++ b/legacy/clang_10/Dockerfile
@@ -68,10 +68,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_11/Dockerfile
+++ b/legacy/clang_11/Dockerfile
@@ -63,10 +63,10 @@ RUN apt-get -qq update \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_3.8/Dockerfile
+++ b/legacy/clang_3.8/Dockerfile
@@ -72,10 +72,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_3.9-x86/Dockerfile
+++ b/legacy/clang_3.9-x86/Dockerfile
@@ -69,10 +69,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_3.9/Dockerfile
+++ b/legacy/clang_3.9/Dockerfile
@@ -78,10 +78,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_4.0-x86/Dockerfile
+++ b/legacy/clang_4.0-x86/Dockerfile
@@ -69,10 +69,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_4.0/Dockerfile
+++ b/legacy/clang_4.0/Dockerfile
@@ -77,10 +77,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_5.0-x86/Dockerfile
+++ b/legacy/clang_5.0-x86/Dockerfile
@@ -65,10 +65,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_5.0/Dockerfile
+++ b/legacy/clang_5.0/Dockerfile
@@ -73,10 +73,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_6.0-x86/Dockerfile
+++ b/legacy/clang_6.0-x86/Dockerfile
@@ -63,10 +63,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_6.0/Dockerfile
+++ b/legacy/clang_6.0/Dockerfile
@@ -71,10 +71,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_7-x86/Dockerfile
+++ b/legacy/clang_7-x86/Dockerfile
@@ -65,10 +65,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_7/Dockerfile
+++ b/legacy/clang_7/Dockerfile
@@ -73,10 +73,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_8-x86/Dockerfile
+++ b/legacy/clang_8-x86/Dockerfile
@@ -65,10 +65,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_8/Dockerfile
+++ b/legacy/clang_8/Dockerfile
@@ -71,10 +71,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_9-x86/Dockerfile
+++ b/legacy/clang_9-x86/Dockerfile
@@ -65,10 +65,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/clang_9/Dockerfile
+++ b/legacy/clang_9/Dockerfile
@@ -73,10 +73,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.6/Dockerfile
+++ b/legacy/gcc_4.6/Dockerfile
@@ -47,10 +47,10 @@ RUN apt-get -qq update \
        --exclude=share/vim \
     && cp -fR /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf /tmp/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.8-x86/Dockerfile
+++ b/legacy/gcc_4.8-x86/Dockerfile
@@ -48,10 +48,10 @@ RUN dpkg --add-architecture i386 \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.8/Dockerfile
+++ b/legacy/gcc_4.8/Dockerfile
@@ -49,10 +49,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.9-armv7/Dockerfile
+++ b/legacy/gcc_4.9-armv7/Dockerfile
@@ -47,10 +47,10 @@ RUN apt-get -qq update \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.9-armv7hf/Dockerfile
+++ b/legacy/gcc_4.9-armv7hf/Dockerfile
@@ -49,10 +49,10 @@ RUN dpkg --add-architecture armhf \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.9-x86/Dockerfile
+++ b/legacy/gcc_4.9-x86/Dockerfile
@@ -55,10 +55,10 @@ RUN dpkg --add-architecture i386 \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_4.9/Dockerfile
+++ b/legacy/gcc_4.9/Dockerfile
@@ -61,10 +61,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_5-x86/Dockerfile
+++ b/legacy/gcc_5-x86/Dockerfile
@@ -51,10 +51,10 @@ RUN apt-get -qq update \
        && make -s install > /dev/null \
        && cd - \
        && rm -rf cmake-* \
-       && groupadd 1001 -g 1001 \
-       && groupadd 1000 -g 1000 \
-       && groupadd 2000 -g 2000 \
-       && groupadd 999 -g 999 \
+       && groupadd -f conan-1001 -g 1001 \
+       && groupadd -f conan-1000 -g 1000 \
+       && groupadd -f conan-2000 -g 2000 \
+       && groupadd -f conan-999 -g 999 \
        && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
        && printf "conan:conan" | chpasswd \
        && adduser conan sudo \

--- a/legacy/gcc_5.2/Dockerfile
+++ b/legacy/gcc_5.2/Dockerfile
@@ -50,10 +50,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_5.3/Dockerfile
+++ b/legacy/gcc_5.3/Dockerfile
@@ -97,10 +97,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_5.4/Dockerfile
+++ b/legacy/gcc_5.4/Dockerfile
@@ -52,10 +52,10 @@ RUN dpkg --add-architecture i386 \
        && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
        && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
        && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       && groupadd 1001 -g 1001 \
-       && groupadd 1000 -g 1000 \
-       && groupadd 2000 -g 2000 \
-       && groupadd 999 -g 999 \
+       && groupadd -f conan-1001 -g 1001 \
+       && groupadd -f conan-1000 -g 1000 \
+       && groupadd -f conan-2000 -g 2000 \
+       && groupadd -f conan-999 -g 999 \
        && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
        && printf "conan:conan" | chpasswd \
        && adduser conan sudo \

--- a/legacy/gcc_5/Dockerfile
+++ b/legacy/gcc_5/Dockerfile
@@ -58,10 +58,10 @@ RUN dpkg --add-architecture i386 \
        && curl -fL https://getcli.jfrog.io | sh \
        && mv jfrog /usr/local/bin/jfrog \
        && chmod +x /usr/local/bin/jfrog \
-       && groupadd 1001 -g 1001 \
-       && groupadd 1000 -g 1000 \
-       && groupadd 2000 -g 2000 \
-       && groupadd 999 -g 999 \
+       && groupadd -f conan-1001 -g 1001 \
+       && groupadd -f conan-1000 -g 1000 \
+       && groupadd -f conan-2000 -g 2000 \
+       && groupadd -f conan-999 -g 999 \
        && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
        && printf "conan:conan" | chpasswd \
        && adduser conan sudo \

--- a/legacy/gcc_6-x86/Dockerfile
+++ b/legacy/gcc_6-x86/Dockerfile
@@ -60,10 +60,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_6.2/Dockerfile
+++ b/legacy/gcc_6.2/Dockerfile
@@ -54,10 +54,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_6.3/Dockerfile
+++ b/legacy/gcc_6.3/Dockerfile
@@ -54,10 +54,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_6.4/Dockerfile
+++ b/legacy/gcc_6.4/Dockerfile
@@ -59,10 +59,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_6/Dockerfile
+++ b/legacy/gcc_6/Dockerfile
@@ -69,10 +69,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_7-x86/Dockerfile
+++ b/legacy/gcc_7-x86/Dockerfile
@@ -60,10 +60,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_7.2/Dockerfile
+++ b/legacy/gcc_7.2/Dockerfile
@@ -57,10 +57,10 @@ RUN dpkg --add-architecture i386 \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
     && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_7/Dockerfile
+++ b/legacy/gcc_7/Dockerfile
@@ -69,10 +69,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_8-x86/Dockerfile
+++ b/legacy/gcc_8-x86/Dockerfile
@@ -58,10 +58,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_8/Dockerfile
+++ b/legacy/gcc_8/Dockerfile
@@ -67,10 +67,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_9-x86/Dockerfile
+++ b/legacy/gcc_9-x86/Dockerfile
@@ -60,10 +60,10 @@ RUN apt-get -qq update \
     && make -s install > /dev/null \
     && cd - \
     && rm -rf cmake-* \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/legacy/gcc_9/Dockerfile
+++ b/legacy/gcc_9/Dockerfile
@@ -69,10 +69,10 @@ RUN dpkg --add-architecture i386 \
     && curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -66,10 +66,10 @@ RUN apt-get -qq update \
     && curl -fL https://getcli.jfrog.io | sh -s 1.48.1 \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
-    && groupadd 1001 -g 1001 \
-    && groupadd 1000 -g 1000 \
-    && groupadd 2000 -g 2000 \
-    && groupadd 999 -g 999 \
+    && groupadd -f conan-1001 -g 1001 \
+    && groupadd -f conan-1000 -g 1000 \
+    && groupadd -f conan-2000 -g 2000 \
+    && groupadd -f conan-999 -g 999 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \


### PR DESCRIPTION
Group name can not be a number since Ubuntu 20.04. Let's use a standard for all images.

`useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999` will not be affected, as it uses the group ID.

closes #322 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
