### PR TITLE
[ci] Fix typo + Do not create _deprecated_ Jenkins images 

### DIFF
--- a/.ci/generate_legacy.jenkinsfile
+++ b/.ci/generate_legacy.jenkinsfile
@@ -215,7 +215,7 @@ node('Linux') {
 
                 String containerID = get_container_id()
 
-                stage("Legacy - ${compiler.toUpperCase()} ${dir} deploy") {
+                stage("Legacy - ${app.toUpperCase()} ${dir} deploy") {
                     String latestBranch = "${dockerUsername}/${app}:${branchName}-latest"
                     String latestMaster = "${dockerUsername}/${app}:${targetBranch}-latest"
 

--- a/.ci/generate_legacy.jenkinsfile
+++ b/.ci/generate_legacy.jenkinsfile
@@ -6,11 +6,9 @@ Notes on this job:
 
 */
 
-
 // Maybe parameterized somewhere
 dockerUsername = 'center-c3i-docker.jfrog.io'
 dockerhubUsername = 'conanio'
-
 
 def buildImage(String latestMaster, String latestBranch, String expectedImage, String buildArgs, String target = null, String extraCacheFrom = null) {
     withCredentials([usernamePassword(credentialsId: 'center-c3i-docker', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -31,7 +29,6 @@ def buildImage(String latestMaster, String latestBranch, String expectedImage, S
     sh "docker tag ${expectedImage} ${latestBranch}"
     sh "docker push ${latestBranch}"
 }
-
 
 def get_container_id() {
     // This is quite fragile and might depends on the Jenkins configuration and deployment, but it is the best
@@ -64,7 +61,7 @@ def checkoutSources() {
         sh "git merge --no-ff ${params.scm_commit}"
     }
     else {
-        echo "Install reference from the SCM repository"
+        echo 'Install reference from the SCM repository'
         checkout([$class           : 'GitSCM',
                     branches         : [[name: params.scm_commit]],
                     userRemoteConfigs: [[credentialsId: 'GITHUB_CLONE', url: params.scm_repository]],
@@ -73,10 +70,24 @@ def checkoutSources() {
     sh 'git log -n 10 --graph --pretty=oneline --abbrev-commit --all --decorate=full'
 }
 
-node('Linux') {
-    List<String> gccVersions = params.gcc_versions.split("\n")
-    List<String> clangVersions = params.clang_versions.split("\n")
+boolean isLegacyJenkinsUsed(String compiler, String version) {
+    // Returns if this legacy image is being used in Jenkins or not. We don't want to create them
+    //  if they are not to be used in the future.
+    int v = version as int
+    if (compiler == 'gcc' && v >= 11) {
+        echo 'Do not create (legacy) jenkins images for GCC >= 11'
+        return false
+    }
+    else if (compiler == 'clang' && v >= 12) {
+        echo 'Do not create (legacy) jenkins images for Clang >= 12'
+        return false
+    }
+    return true
+}
 
+node('Linux') {
+    List<String> gccVersions = params.gcc_versions.split('\n')
+    List<String> clangVersions = params.clang_versions.split('\n')
 
     stage('Legacy - Input parameters') {
         echo """
@@ -106,8 +117,8 @@ node('Linux') {
         - gcc_versions: ${gccVersions.join(', ')}
         - clang_versions: ${clangVersions.join(', ')}
         """
-        assert gccVersions.size() > 0: "Expecting to build some GCC versions at least"
-        assert clangVersions.size() > 0: "Expecting to build some Clang versions at least"
+        assert gccVersions.size() > 0: 'Expecting to build some GCC versions at least'
+        assert clangVersions.size() > 0: 'Expecting to build some Clang versions at least'
 
         echo """
         About docker images generated:
@@ -148,14 +159,14 @@ node('Linux') {
     // Build build-args list
     Map<String, String> buildArguments = [:]
     Map<String, String> testArguments = [:]
-    stage("Legacy - Build arguments") {
+    stage('Legacy - Build arguments') {
         buildArguments.put('CONAN_VERSION', params.conan_version)
 
         // TODO: Pass expected in a different way
-        writeFile(file: 'legacy/.env', text: testArguments.collect({ k, v -> "${k }=${v }"}).join('\n') as String)
+        writeFile(file: 'legacy/.env', text: testArguments.collect({ k, v -> "${k }=${v }" }).join('\n') as String)
         sh 'cat legacy/.env'
     }
-    String buildArgs = buildArguments.collect({ k, v -> "--build-arg ${k }=${v }"}).join(' ') as String
+    String buildArgs = buildArguments.collect({ k, v -> "--build-arg ${k }=${v }" }).join(' ') as String
 
     // Execute login: 1) Validate the login 2) Needed for docker pull/push
     withCredentials([usernamePassword(credentialsId: 'center-c3i-docker', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -188,13 +199,15 @@ node('Linux') {
                     }
                 }
 
-                stage("Legacy - ${compiler.toUpperCase()} ${version} jenkins") {
-                    String latestBranch = "${dockerUsername}/${compiler}${versionMajor}-jnlp-slave:${branchName}-latest"
-                    String latestMaster = "${dockerUsername}/${compiler}${versionMajor}-jnlp-slave:${targetBranch}-latest"
+                if (isLegacyJenkinsUsed(compiler, version)) {
+                    stage("Legacy - ${compiler.toUpperCase()} ${version} jenkins") {
+                        String latestBranch = "${dockerUsername}/${compiler}${versionMajor}-jnlp-slave:${branchName}-latest"
+                        String latestMaster = "${dockerUsername}/${compiler}${versionMajor}-jnlp-slave:${targetBranch}-latest"
 
-                    dir('legacy/jenkins-jnlp-slave') {
-                        String jenkins_args = "--build-arg SOURCE_CONANIO_IMAGE=${deployImage} --build-arg AGENT_VERSION=${params.jenkins_agent_version}"
-                        buildImage(latestMaster, latestBranch, jenkinsImage, "${compilerArgs} ${jenkins_args}")
+                        dir('legacy/jenkins-jnlp-slave') {
+                            String jenkins_args = "--build-arg SOURCE_CONANIO_IMAGE=${deployImage} --build-arg AGENT_VERSION=${params.jenkins_agent_version}"
+                            buildImage(latestMaster, latestBranch, jenkinsImage, "${compilerArgs} ${jenkins_args}")
+                        }
                     }
                 }
             }
@@ -239,7 +252,6 @@ node('Linux') {
     gccBuilds.failFast = true
     parallel(gccBuilds)
 
-
     // Build Clang in parallel
     Map clangBuilds = [:]
     List<String> clangImages = []
@@ -254,14 +266,14 @@ node('Linux') {
 
     if (params.build_conan_client) {
         Map conanClientBuilds = [:]
-        conanClientBuilds["Legacy Conan Client"] = appBuild('conan_client', 'conan')
+        conanClientBuilds['Legacy Conan Client'] = appBuild('conan_client', 'conan')
         conanClientBuilds.failFast = true
         parallel(conanClientBuilds)
     }
 
     if (params.build_conan_server) {
         Map conanServerBuilds = [:]
-        conanServerBuilds["Legacy Conan Serve"] = appBuild('conan_server', 'conan_server')
+        conanServerBuilds['Legacy Conan Serve'] = appBuild('conan_server', 'conan_server')
         conanServerBuilds.failFast = true
         parallel(conanServerBuilds)
     }
@@ -275,7 +287,7 @@ node('Linux') {
                 if (params.upload_main_images) {
                     images.add("gcc${versionMajor}")
                 }
-                if (params.upload_jenkins_images) {
+                if (params.upload_jenkins_images && isLegacyJenkinsUsed('gcc', versionMajor)) {
                     images.add("gcc${versionMajor}-jnlp-slave")
                 }
             }
@@ -284,15 +296,15 @@ node('Linux') {
                 if (params.upload_main_images) {
                     images.add("clang${versionMajor}")
                 }
-                if (params.upload_jenkins_images) {
+                if (params.upload_jenkins_images && isLegacyJenkinsUsed('clang', versionMajor)) {
                     images.add("clang${versionMajor}-jnlp-slave")
                 }
             }
             if (params.build_conan_client) {
-                images.add("conan")
+                images.add('conan')
             }
             if (params.build_conan_server) {
-                images.add("conan_server")
+                images.add('conan_server')
             }
 
             images.each { image ->
@@ -321,5 +333,4 @@ node('Linux') {
             }
         }
     }
-
 }


### PR DESCRIPTION
Don't create deprecated Jenkins images:
 * GCC 11 (and above) is already using modern images
 * Clang 12 (and above) is using modern images.

These are the relevant snippets from CCI configuration (please, double check):

```
node_labels:
  Linux:
    x86_64:
      "gcc":
        default: "linux_gcc_${compiler.version}"
        "11": "linux_gcc_${compiler.version}_ubuntu16.04"
      "clang":
        default: "linux_clang_${compiler.version}_ubuntu16.04"
        "11": "linux_clang_${compiler.version}"
```
