### PR TITLE
Patch lsb_release for Clang 10 and Clang 11

### DIFF
--- a/legacy/clang_10/Dockerfile
+++ b/legacy/clang_10/Dockerfile
@@ -83,6 +83,7 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/${PYTHON_VERSION}/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools cmake==${CMAKE_VERSION_FULL} \
     && chown -R conan:1001 /opt/pyenv \

--- a/legacy/clang_11/Dockerfile
+++ b/legacy/clang_11/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get -qq update \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/${PYTHON_VERSION}/lib/python3.7/lsb_release.py \
     && pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools cmake==${CMAKE_VERSION_FULL} \
     && chown -R conan:1001 /opt/pyenv \


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/10795

lsb_release is an APT package which wants the python from the system, not from pyenv, which causes a mess when trying to execute from pyenv version.

As workaround, we link the original script to pyenv folder, so we "install" lsb_release to our global python version.

We already did it in the past, but forgot to add for new clang images. For modern images it's not required, lsb_release works there.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
