### PR TITLE
[skip ci] update stale time

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 30
+daysUntilStale: 180
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 30
+daysUntilClose: 90
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []


### PR DESCRIPTION
The CDT is not so active to start to close issues and PR every months. Some questions need months to get feedback or even non prioritized features can take many months. Let's update the stale bot to wait 6 months to put as `stale` state + 3 months to close a staled issue.
