### PR TITLE
Remove system dev packages for modern images

### DIFF
--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -93,7 +93,21 @@ RUN apt-get -qq update \
     && mv /etc/ld.so.conf.d/libc.conf /etc/ld.so.conf.d/10libc.conf \
     && rm /etc/ld.so.cache \
     && ldconfig -C /etc/ld.so.cache \
-    && apt-get -qq purge -y g++-multilib gcc \
+    && apt-get -qq purge -y \
+       g++-multilib \
+       gcc \
+       libgmp-dev \
+       libmpfr-dev \
+       libmpc-dev \
+       libffi-dev \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       libsqlite3-dev \
+       libreadline-dev \
+       libncurses5-dev \
+       libncursesw5-dev \
+       liblzma-dev \
     && apt-get -qq autoremove -y \
     && apt-get -qq autoclean \
     && apt-get -qq update \


### PR DESCRIPTION
All dev ubuntu packages should be consumed from Conan Center, otherwise, our package can consume from system by mistake.

All removed packages are present in Conan Center.

Let's start with modern, then, we can go with legacy.

/cc @jcar87

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
