### PR TITLE
Fix conan version location

### DIFF
--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -7,8 +7,8 @@ This pipeline is used to generate docker images for ConanCenter index
 
 @NonCPS
 def getMinConanVersion(content) {
-    def minVersion = (content =~ /String conanVersion = '(\d+).(\d+).(\d+)'/)
-    assert minVersion, '.ci/tests.jenkins file was changed! Cannot find conanVersion'
+    def minVersion = (content =~ /  v1_required: (\d+).(\d+).(\d+)/)
+    assert minVersion, 'configs/library_requirements.yml file was changed! Cannot find conanVersion'
     return [minVersion[0][1] as int, minVersion[0][2] as int, minVersion[0][3] as int]
 }
 
@@ -38,7 +38,7 @@ node('Linux') {
     String preVersionStr = null
     stage('Compute Conan versions') {
         dir('tmp') {
-            // Minimum from https://github.com/conan-io/c3i_jenkins/blob/master/.ci/tests.jenkins
+            // Minimum from https://github.com/conan-io/c3i_jenkins/blob/master/resources/org/jfrog/c3i/configs/library_requirements.yml
             echo "Read lowest version from CCI requirements"
             checkout([$class           : 'GitSCM',
                     branches         : [[name: 'master']],
@@ -46,7 +46,7 @@ node('Linux') {
                     extensions       : [[$class           : 'RelativeTargetDirectory',
                                         relativeTargetDir: 'c3i_jenkins']],
             ])
-            def content = readFile "${env.WORKSPACE}/tmp/c3i_jenkins/.ci/tests.jenkins"
+            def content = readFile "${env.WORKSPACE}/tmp/c3i_jenkins/resources/org/jfrog/c3i/configs/library_requirements.yml"
             def minVersion = getMinConanVersion(content)
             echo " - lowest: $minVersion"
 

--- a/.ci/conan_center_index_legacy.jenkinsfile
+++ b/.ci/conan_center_index_legacy.jenkinsfile
@@ -7,8 +7,8 @@ This pipeline is used to generate docker images for ConanCenter index
 
 @NonCPS
 def getMinConanVersion(content) {
-    def minVersion = (content =~ /String conanVersion = '(\d+).(\d+).(\d+)'/)
-    assert minVersion, '.ci/tests.jenkins file was changed! Cannot find conanVersion'
+    def minVersion = (content =~ /  v1_required: (\d+).(\d+).(\d+)/)
+    assert minVersion, 'configs/library_requirements.yml file was changed! Cannot find conanVersion'
     return [minVersion[0][1] as int, minVersion[0][2] as int, minVersion[0][3] as int]
 }
 
@@ -38,7 +38,7 @@ node('Linux') {
                     extensions       : [[$class           : 'RelativeTargetDirectory',
                                         relativeTargetDir: 'c3i_jenkins']],
             ])
-            def content = readFile "${env.WORKSPACE}/tmp/c3i_jenkins/.ci/tests.jenkins"
+            def content = readFile "${env.WORKSPACE}/tmp/c3i_jenkins/resources/org/jfrog/c3i/configs/library_requirements.yml"
             def minVersion = getMinConanVersion(content)
             echo " - lowest: $minVersion"
 


### PR DESCRIPTION
CDT build specific images for Conan Center based on the official Conan version running.

We moved the location of the current version.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
