### PR TITLE
[hotfix] GCC build option: nsl should be nls instead

### DIFF
--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -32,11 +32,18 @@ RUN apt-get -qq update \
 RUN wget -q --no-check-certificate http://mirrors.concertpass.com/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz \
     && tar Jxf gcc-${GCC_VERSION}.tar.xz
 
+# INFO: GCC build reference: https://gcc.gnu.org/install/configure.html
+# Disabling bootstrap save us around 1h
+# Disable multilib as Conan Center no longer supports x86
+# Enable Fortran as lapack package is basically broken
+# No nls (native language support) because we only use English in Conan Center
+
 RUN cd gcc-${GCC_VERSION} \
-    && ./configure --build=x86_64-linux-gnu \
+    && ./configure \
+                   --build=x86_64-linux-gnu \
                    --disable-bootstrap \
                    --disable-multilib \
-                   --disable-nsl \
+                   --disable-nls \
                    --enable-languages=c,c++,fortran \
                    --disable-werror \
                    --without-isl \


### PR DESCRIPTION
Fix: Wrong option disabled for GCC build is not check by configure. Maybe GCC bootstrap does it, but it would increase our build time by 1h at least.

closes #460

/cc @maksim-petukhov

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
