### PR TITLE
[ci] Tag conan v2 images with real name [skip-ci]

### DIFF
--- a/.ci/generate.jenkinsfile
+++ b/.ci/generate.jenkinsfile
@@ -352,12 +352,8 @@ node('Linux') {
                 withCredentials([usernamePassword(credentialsId: 'docker-credentials', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh 'docker login --username $USERNAME --password $PASSWORD'
                 }
-                String tagVersion = params.conan_version
-                def (major, minor, patch) = parseVersion(params.conan_version)
-                if (major == '2') {
-                    tagVersion = "${major}.${minor}.${patch}-pre"
-                }
 
+                String tagVersion = params.conan_version
                 // Upload with the corresponding tag version
                 String uploadImage = "${dockerhubUsername}/${image}:${tagVersion}"
                 sh "docker tag ${builtImage} ${uploadImage}"
@@ -376,5 +372,4 @@ node('Linux') {
             }
         }
     }
-
 }


### PR DESCRIPTION
Changelog: Fix: Generate conan v2 images with their real version as tag

Right now is getting complicated to know what beta version the label `2.0.0-pre` ins dockerhub has. At the point that, even in c3i, the version is not consistent and we are failing to have control over that version.

In this PR, I remove the `-pre` logic and just leave the version untouched to be pushed as the image label.
