### PR TITLE
Build conan 2.0 by default

### DIFF
--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -17,12 +17,6 @@ def parseVersion(String version) {
     return [matcher[0][1] as int, matcher[0][2] as int, matcher[0][3] as int]
 }
 
-def parsePreVersion(String version) {
-    def matcher = (version =~ /(\d+).(\d+).(\d+)(\w)(\d+)/)
-    return [matcher[0][1] as int, matcher[0][2] as int, matcher[0][3] as int, matcher[0][4] as char, matcher[0][5] as int]
-}
-
-
 node('Linux') {
 
     stage('Input parameters') {
@@ -34,8 +28,6 @@ node('Linux') {
     def conanVersions = []
     List<String> ignoreVersions = []
     String latestVersion = null
-    def preVersion = null
-    String preVersionStr = null
     stage('Compute Conan versions') {
         dir('tmp') {
             // Minimum from https://github.com/conan-io/c3i_jenkins/blob/master/resources/org/jfrog/c3i/configs/library_requirements.yml
@@ -71,15 +63,6 @@ node('Linux') {
                         echo "WARNING: The version '$release' is explicitly ignored."
                         continue
                     }
-
-                    // Build only the latest 2.0.0-pre version
-                    if (version[0] == 2) {
-                        def (major, minor, patch, pre, preNumber) = parsePreVersion(release)
-                        if (!preVersion || (pre > preVersion[3]) || (pre == preVersion[3] && preNumber > preVersion[4])) {
-                            preVersion = [major, minor, patch, pre, preNumber]
-                            preVersionStr = "${major}.${minor}.${patch}-${pre == 'a' ? 'alpha' : (pre == 'b' ? 'beta' : pre)}${preNumber}"
-                        }
-                    }
                     else if (version[0] > minVersion[0]) {
                         conanVersions.add(release)
                     }
@@ -94,16 +77,11 @@ node('Linux') {
                     echo "Failed to parse release '$release'"
                 }
             }
-
-            if (preVersion) {
-                conanVersions.add(preVersionStr)
-            }
         }
     }
 
     echo "Versions: ${conanVersions}"
     echo "- latest: ${latestVersion}"
-    echo "- preVersion: ${preVersionStr}"
 
     List parameters = []
 

--- a/.ci/generate.jenkinsfile
+++ b/.ci/generate.jenkinsfile
@@ -361,8 +361,7 @@ node('Linux') {
                     sh "docker push ${uploadImage}"
                 }
 
-                def (conanVersionMajor, _1, _2) = parseVersion(params.conan_version)
-                if (params.upload_latest && conanVersionMajor == '1') {
+                if (params.upload_latest) {
                     // Upload with tag 'latest'
                     String uploadLatest = "${dockerhubUsername}/${image}:latest"
                     sh "docker tag ${builtImage} ${uploadLatest}"


### PR DESCRIPTION
Conan 2.0 is now stable and need to be built for every new client release. 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
