### PR TITLE
[ci] Build only 3 latest versions of Conan 2.x

### DIFF
--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -84,6 +84,12 @@ node('Linux') {
                 }
             }
             conanVersions = conanVersions.reverse()
+
+            // Ensure at least one version of Conan 1.x and three from Conan 2.x
+            def conan2Versions = conanVersions.findAll{element -> element[0] == '2'}
+            conan2Versions = conan2Versions.size() > 3 ? conan2Versions.subList(0, 3) : conan2Versions
+            def conan1Versions = conanVersions.findAll{element -> element[0] == '1'}
+            conanVersions = conan2Versions + conan1Versions
         }
     }
 


### PR DESCRIPTION
To avoid extra CI resource, let's build only 3 latest versions of Conan 2.x available.

Plus, continue to build the latest 1.x version available for CCI.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
