### PR TITLE
[clang11] Use Ubuntu focal (20.04) as base image

### DIFF
--- a/legacy/clang_11/Dockerfile
+++ b/legacy/clang_11/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -qq update \
        libncurses5-dev \
        libncursesw5-dev \
        liblzma-dev \
-    && printf 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-11  main' >> /etc/apt/sources.list \
+    && printf 'deb http://apt.llvm.org/focal/   llvm-toolchain-focal-11  main' >> /etc/apt/sources.list \
     && wget --no-check-certificate --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends --no-install-suggests \

--- a/legacy/clang_11/Dockerfile
+++ b/legacy/clang_11/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 


### PR DESCRIPTION
The image Bionic (18.04) provides libstdc++-6.so on the version 3.4.25 which does not allow using C++17 libraries like `std::filesystem`. Unfortunately, it's not possible to obtain a newer version directly from Ubuntu Bionic official repository.

As solution, we can update the base distro to Focal (20.04) that contains a newer version of libstd++ 3.4.28 and supports C++17.

The same for glibc version, Bionic supports 2.27 and Focal provides 2.31.

As both glibc and libstdc++ are backward compatible, it should not break CCI.

Doing a local test, by consuming packages produced by the current Docker image `conanio/clang11:1.59.0` in a new image based on Focal, it worked without errors.

Related to https://github.com/conan-io/conan-center-index/pull/16938

/cc @czoido 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
