### PR TITLE
Fix tag name for jenkins images

### DIFF
--- a/.ci/generate.jenkinsfile
+++ b/.ci/generate.jenkinsfile
@@ -409,7 +409,7 @@ node('Linux') {
 
                     if (params.upload_latest) {
                         // Upload with tag 'latest'
-                        String uploadNewLatest = "${dockerhubUsername}/${image}:latest-${tagNewVersion}"
+                        String uploadNewLatest = "${dockerhubUsername}/${image}:latest-${params.jenkins_agent_new_version}"
                         sh "docker tag ${builtNewImage} ${uploadNewLatest}"
                         if (!params.dry_run) {
                             sh "docker push ${uploadNewLatest}"


### PR DESCRIPTION
The jenkins images should be `latest-4.9`, not `latest-<conan-version>-4.9`



- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
