### PR TITLE
gcc: always pass --build-id to linker

### DIFF
--- a/modern/gcc/Dockerfile
+++ b/modern/gcc/Dockerfile
@@ -49,6 +49,7 @@ RUN cd gcc-${GCC_VERSION} \
                    --without-isl \
                    --with-system-zlib \
                    --prefix=/tmp/install \
+                   --enable-linker-build-id \
     && make -s -j$(nproc) \
     && make install-strip
 


### PR DESCRIPTION
As mentioned in
https://github.com/conan-io/conan-center-index/issues/18809, currently some conan shared libraries are build without .note.gnu.build-id note and thus one cannot link separated debug info ELF file with the shared library. It is something CPack complains about: https://github.com/Kitware/CMake/blob/master/Modules/Internal/CPack/CPackDeb.cmake#L231

GCC documentation of the added option:
https://gcc.gnu.org/install/configure.html

Changelog: Bugfix: Describe here your pull request

- [ ] Fixes https://github.com/conan-io/conan-center-index/issues/18809 where some Conan packages with shared libraries are missing `.note.gnu.build-id ` section