### PR TITLE
Introduce retry for builds when generating Docker images in CI

### DIFF
--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -171,10 +171,13 @@ node('Linux') {
     for (strVersion in conanVersions) {
         boolean isLatest = (strVersion == latestVersion)
         stage("Build images for Conan '${strVersion}' (latest=${isLatest})") {
-            build(job: 'ConanDockerTools/_generate', propagate: true, wait: true, parameters: parameters + [
-                [$class: 'StringParameterValue', name: 'conan_version', value: strVersion],
-                [$class: 'BooleanParameterValue', name: 'upload_latest', value: isLatest],
-            ])
+            // INFO: When building docker images, networking errors are frequent. We retry 3 times.
+            retry(3) {
+                build(job: 'ConanDockerTools/_generate', propagate: true, wait: true, parameters: parameters + [
+                    [$class: 'StringParameterValue', name: 'conan_version', value: strVersion],
+                    [$class: 'BooleanParameterValue', name: 'upload_latest', value: isLatest],
+                ])
+            }
         }
     }
 }

--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -27,6 +27,7 @@ node('Linux') {
     stage('Input parameters') {
         echo """
         - dry_run: ${params.dry_run}
+        - conan_versions: ${params.conan_versions}
         """
     }
 
@@ -34,6 +35,13 @@ node('Linux') {
     List<String> ignoreVersions = []
     String latestVersion = null
     stage('Compute Conan versions') {
+        if (params.conan_versions) {
+            conanVersions = params.conan_versions.trim().split(',')
+            // INFO: Check that all versions are valid
+            conanVersions.collect{ parseVersion(it) }
+            echo "INFO: Skipping Conan versions computation because of input parameter."
+        }
+
         dir('tmp') {
             // Minimum from https://github.com/conan-io/c3i_jenkins/blob/master/resources/org/jfrog/c3i/configs/library_requirements.yml
             echo "Read lowest version from CCI requirements"
@@ -52,9 +60,14 @@ node('Linux') {
             def response = httpRequest(url: 'https://pypi.org/pypi/conan/json')
             Map<String, Object> requestJson = readJSON(text: response.content)
             latestVersion = requestJson.info.version
+            def keyVersions = requestJson.releases.keySet()
 
-            for (String release in requestJson.releases.keySet()) {
+            echo "INFO: Latest version available in pypi: ${latestVersion}"
+            echo "INFO: Found versions in pypi: ${keyVersions.size()}"
+
+            for (String release in keyVersions) {
                 try {
+                    echo "DEBUG: Parsing release '$release'"
                     def version = parseVersion(release)
 
                     // Ignore Conan < 1.44: https://github.com/conan-io/conan/issues/10611
@@ -70,12 +83,15 @@ node('Linux') {
                     }
 
                     if (version[0] > minVersion[0] && !hasPreVersion(release)) {
+                        echo "DEBUG: Adding '$release' to the list of versions because of major version."
                         conanVersions.add(release)
                     }
                     else if (version[0] == minVersion[0] && version[1] > minVersion[1]) {
+                        echo "DEBUG: Adding '$release' to the list of versions because of minor version."
                         conanVersions.add(release)
                     }
                     else if (version[0] == minVersion[0] && version[1] == minVersion[1] &&  version[2] >= minVersion[2]) {
+                        echo "DEBUG: Adding '$release' to the list of versions because of patch version."
                         conanVersions.add(release)
                     }
                 }
@@ -84,6 +100,7 @@ node('Linux') {
                 }
             }
             conanVersions = conanVersions.reverse()
+            echo "DEBUG: Filtering Conan versions: ${conanVersions}"
 
             // Ensure at least one version of Conan 1.x and three from Conan 2.x
             def conan2Versions = conanVersions.findAll{element -> element[0] == '2'}
@@ -93,8 +110,8 @@ node('Linux') {
         }
     }
 
-    echo "Versions: ${conanVersions}"
-    echo "- latest: ${latestVersion}"
+    echo "INFO: Conan versions: ${conanVersions}"
+    echo "INFO: Conan latest version: ${latestVersion}"
 
     List parameters = []
 

--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -40,6 +40,7 @@ node('Linux') {
             // INFO: Check that all versions are valid
             conanVersions.collect{ parseVersion(it) }
             echo "INFO: Skipping Conan versions computation because of input parameter."
+            return
         }
 
         dir('tmp') {

--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -49,7 +49,7 @@ node('Linux') {
 
             // Up to latest version in pypi
             echo "Read latest version from pypi"
-            def response = httpRequest(url: 'https://pypi.python.org/pypi/conan/json')
+            def response = httpRequest(url: 'https://pypi.org/pypi/conan/json')
             Map<String, Object> requestJson = readJSON(text: response.content)
             latestVersion = requestJson.info.version
 

--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -44,7 +44,7 @@ node('Linux') {
 
         dir('tmp') {
             // Minimum from https://github.com/conan-io/c3i_jenkins/blob/master/resources/org/jfrog/c3i/configs/library_requirements.yml
-            echo "Read lowest version from CCI requirements"
+            echo "INFO: Read lowest version from CCI requirements"
             checkout([$class           : 'GitSCM',
                     branches         : [[name: 'master']],
                     userRemoteConfigs: [[credentialsId: 'conanci-gh-token', url: 'https://github.com/conan-io/c3i_jenkins.git']],

--- a/.ci/conan_center_index_legacy.jenkinsfile
+++ b/.ci/conan_center_index_legacy.jenkinsfile
@@ -38,6 +38,7 @@ node('Linux') {
             // INFO: Check that all versions are valid
             conanVersions.collect{ parseVersion(it) }
             echo "INFO: Skipping Conan versions computation because of input parameter."
+            return
         }
 
         dir('tmp') {

--- a/.ci/conan_center_index_legacy.jenkinsfile
+++ b/.ci/conan_center_index_legacy.jenkinsfile
@@ -106,10 +106,13 @@ node('Linux') {
         String strVersion = "${v[0]}.${v[1]}.${v[2]}"
         boolean isLatest = (v == latestVersion)
         stage("Build legacy images for Conan '${strVersion}' (latest=${isLatest})") {
-            build(job: 'ConanDockerTools/_generate_legacy', propagate: true, wait: true, parameters: parameters + [
-                [$class: 'StringParameterValue', name: 'conan_version', value: strVersion],
-                [$class: 'BooleanParameterValue', name: 'upload_latest', value: isLatest],
-            ])
+            // INFO: When building docker images, networking errors are frequent. We retry 3 times.
+            retry(3) {
+                build(job: 'ConanDockerTools/_generate_legacy', propagate: true, wait: true, parameters: parameters + [
+                    [$class: 'StringParameterValue', name: 'conan_version', value: strVersion],
+                    [$class: 'BooleanParameterValue', name: 'upload_latest', value: isLatest],
+                ])
+            }
         }
     }
 }

--- a/.ci/conan_center_index_legacy.jenkinsfile
+++ b/.ci/conan_center_index_legacy.jenkinsfile
@@ -26,15 +26,23 @@ node('Linux') {
     stage('Input parameters') {
         echo """
         - dry_run: ${params.dry_run}
+        - conan_versions: ${params.conan_versions}
         """
     }
 
     def conanVersions = []
     def latestVersion = null
     stage('Legacy - Compute Conan versions') {
+        if (params.conan_versions) {
+            conanVersions = params.conan_versions.trim().split(',')
+            // INFO: Check that all versions are valid
+            conanVersions.collect{ parseVersion(it) }
+            echo "INFO: Skipping Conan versions computation because of input parameter."
+        }
+
         dir('tmp') {
             // Minimum from https://github.com/conan-io/c3i_jenkins/blob/master/.ci/tests.jenkins
-            echo "Read lowest version from CCI requirements"
+            echo "INFO: Read lowest version from CCI requirements"
             checkout([$class           : 'GitSCM',
                     branches         : [[name: 'master']],
                     userRemoteConfigs: [[credentialsId: 'conanci-gh-token', url: 'https://github.com/conan-io/c3i_jenkins.git']],
@@ -50,21 +58,30 @@ node('Linux') {
             def response = httpRequest(url: 'https://pypi.python.org/pypi/conan/json')
             Map<String, Object> requestJson = readJSON(text: response.content)
             latestVersion = parseVersion(requestJson.info.version)
+            def keyVersions = requestJson.releases.keySet()
 
-            for (String release in requestJson.releases.keySet()) {
+            echo "INFO: Latest version available in pypi: ${latestVersion}"
+            echo "INFO: Found versions in pypi: ${keyVersions.size()}"
+
+            for (String release in keyVersions) {
                 try {
+                    echo "DEBUG: Parsing release '$release'"
                     def version = parseVersion(release)
+
                     if (version[0] == 2) {
                         echo "WARNING: The version '$release' is part of Conan 2.0 which will not be built for legacy images."
                         continue
                     }
                     else if (version[0] > minVersion[0]) {
+                        echo "DEBUG: Adding '$release' to the list of versions because of major version."
                         conanVersions.add(version)
                     }
                     else if (version[0] == minVersion[0] && version[1] > minVersion[1]) {
+                        echo "DEBUG: Adding '$release' to the list of versions because of minor version."
                         conanVersions.add(version)
                     }
                     else if (version[0] == minVersion[0] && version[1] == minVersion[1] &&  version[2] >= minVersion[2]) {
+                        echo "DEBUG: Adding '$release' to the list of versions because of patch version."
                         conanVersions.add(version)
                     }
                 }
@@ -74,8 +91,8 @@ node('Linux') {
             }
         }
     }
-    echo "Versions: ${conanVersions}"
-    echo "- latest: ${latestVersion}"
+    echo "INFO: Conan versions: ${conanVersions}"
+    echo "INFO: Conan latest version: ${latestVersion}"
 
     List parameters = []
 

--- a/.ci/conan_center_index_legacy.jenkinsfile
+++ b/.ci/conan_center_index_legacy.jenkinsfile
@@ -55,7 +55,7 @@ node('Linux') {
 
             // Up to latest version in pypi
             echo "Read latest version from pypi"
-            def response = httpRequest(url: 'https://pypi.python.org/pypi/conan/json')
+            def response = httpRequest(url: 'https://pypi.org/pypi/conan/json')
             Map<String, Object> requestJson = readJSON(text: response.content)
             latestVersion = parseVersion(requestJson.info.version)
             def keyVersions = requestJson.releases.keySet()


### PR DESCRIPTION
Frequently we have problems when generating Docker images, mainly when installing APT packages, resulting in the entire build failed. This hotfix introduces retry context to avoid more delays when having a failed job. 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
