### PR TITLE
[ci] Skip building clang for legacy images

### DIFF
--- a/.ci/generate_legacy.jenkinsfile
+++ b/.ci/generate_legacy.jenkinsfile
@@ -96,9 +96,20 @@ boolean isLegacyJenkinsUsed(String compiler, String version) {
     return true
 }
 
+List<String> parseVersions(String versions) {
+    List<String> result = []
+    versions.split('\n').each { v ->
+        String version = v.trim()
+        if (version.size() > 0 && version.isNumber()) {
+            result.add(version)
+        }
+    }
+    return result
+}
+
 node('Linux') {
-    List<String> gccVersions = params.gcc_versions.split('\n')
-    List<String> clangVersions = params.clang_versions.split('\n')
+    List<String> gccVersions = parseVersions(params.gcc_versions)
+    List<String> clangVersions = parseVersions(params.clang_versions)
 
     environment {
         DOCKER_BUILDKIT = 0
@@ -134,7 +145,9 @@ node('Linux') {
         - clang_versions: ${clangVersions.join(', ')}
         """
         assert gccVersions.size() > 0: 'Expecting to build some GCC versions at least'
-        assert clangVersions.size() > 0: 'Expecting to build some Clang versions at least'
+        if (clangVersion.size() == 0) {
+            echo 'WARNING: No Clang versions to build'
+        }
 
         echo """
         About docker images generated:


### PR DESCRIPTION
The docker images in the legacy folder to Clang are no longer used in ConanCenterIndex.

They are no longer mandatory for CI Conan.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
