### PR TITLE
Add the packaging and mako Python modules

### DIFF
--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -124,4 +124,4 @@ WORKDIR /home/conan
 RUN pip install conan~=1.0 \
     && CONAN_REVISIONS_ENABLED=1 CONAN_USER_HOME=/tmp/conan conan install -r conancenter -g deploy -if /opt/conan -l /opt/conan/conan.lock /opt/conan/conanfile.txt \
     && rm -rf /tmp/conan \
-    && pip install conan==${CONAN_VERSION} packaging==23.2
+    && pip install conan==${CONAN_VERSION} mako==1.3.0 packaging==23.2

--- a/modern/base/Dockerfile
+++ b/modern/base/Dockerfile
@@ -124,4 +124,4 @@ WORKDIR /home/conan
 RUN pip install conan~=1.0 \
     && CONAN_REVISIONS_ENABLED=1 CONAN_USER_HOME=/tmp/conan conan install -r conancenter -g deploy -if /opt/conan -l /opt/conan/conan.lock /opt/conan/conanfile.txt \
     && rm -rf /tmp/conan \
-    && pip install conan==${CONAN_VERSION}
+    && pip install conan==${CONAN_VERSION} packaging==23.2


### PR DESCRIPTION
Changelog: Feature:

The packaging Python module is required for glib.
This dependency was added [here](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3740) in order to support Python 3.12 which removed the distutils module.
conan-io/conan-center-index#21535 is a backport of this change for CCI which allows building recent versions of glib with Python 3.12.

The mako Python module is required for the Mesa Conan package in conan-io/conan-center-index#20528.

I'm not sure if I need to update the legacy images as well.
Please let me know if I should.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [x] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
