### PR TITLE
Removed support for conan-server and conan-client docker images

### DIFF
--- a/.ci/conan_center_index_legacy.jenkinsfile
+++ b/.ci/conan_center_index_legacy.jenkinsfile
@@ -128,8 +128,6 @@ node('Linux') {
     parameters.add([$class: 'BooleanParameterValue', name: 'upload_main_images', value: true])
     parameters.add([$class: 'BooleanParameterValue', name: 'upload_jenkins_images', value: true])
     parameters.add([$class: 'BooleanParameterValue', name: 'dry_run', value: params.dry_run])
-    parameters.add([$class: 'BooleanParameterValue', name: 'build_conan_server', value: true])
-    parameters.add([$class: 'BooleanParameterValue', name: 'build_conan_client', value: true])
 
     for (v in conanVersions) {
         String strVersion = "${v[0]}.${v[1]}.${v[2]}"

--- a/.ci/generate_legacy.jenkinsfile
+++ b/.ci/generate_legacy.jenkinsfile
@@ -300,20 +300,6 @@ node('Linux') {
     clangBuilds.failFast = true
     parallel(clangBuilds)
 
-    if (params.build_conan_client) {
-        Map conanClientBuilds = [:]
-        conanClientBuilds['Legacy Conan Client'] = appBuild('conan_client', 'conan')
-        conanClientBuilds.failFast = true
-        parallel(conanClientBuilds)
-    }
-
-    if (params.build_conan_server) {
-        Map conanServerBuilds = [:]
-        conanServerBuilds['Legacy Conan Serve'] = appBuild('conan_server', 'conan_server')
-        conanServerBuilds.failFast = true
-        parallel(conanServerBuilds)
-    }
-
     if (isMaster) {
         // If it was master and everything is ok up to here
         stage('Legacy - Upload images') {
@@ -335,12 +321,6 @@ node('Linux') {
                 if (params.upload_jenkins_images && isLegacyJenkinsUsed('clang', versionMajor)) {
                     images.add("clang${versionMajor}-jnlp-slave")
                 }
-            }
-            if (params.build_conan_client) {
-                images.add('conan')
-            }
-            if (params.build_conan_server) {
-                images.add('conan_server')
             }
 
             images.each { image ->

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -112,17 +112,21 @@ To learn how to build using Android docker images, please, visit [official docs]
 
 Conan Docker Tools provides an image version with only Conan Server installed, very useful for the cases it is necessary to run a server without touching the host.
 
+**NOTE**: In case looking for a Conan server, please, try Artifactory (including docker image) listed at https://conan.io/downloads
+
 | Version                                                                                       | Arch   | Status, Life cycle           |
 |-----------------------------------------------------------------------------------------------|--------|------------------------------|
-| [conanio/conan_server](https://hub.docker.com/r/conanio/conan_server/)                        | ANY    | :white_check_mark: Supported |
+| [conanio/conan_server](https://hub.docker.com/r/conanio/conan_server/)                        | ANY    | :warning: Deprecated         |
 
 #### Conan Client
 
 Conan Docker Tools provides an image version with only Conan client installed, very useful for the cases it is necessary to run a command without touching the host.
 
+**NOTE**: Please, check self-contained version at https://conan.io/downloads in case you need a minimal executable
+
 | Version                                                                                       | Arch   | Status, Life cycle           |
 |-----------------------------------------------------------------------------------------------|--------|------------------------------|
-| [conanio/conan](https://hub.docker.com/r/conanio/conan/)                                      | ANY    | :white_check_mark: Supported |
+| [conanio/conan](https://hub.docker.com/r/conanio/conan/)                                      | ANY    | :warning: Deprecated         |
 
 
 #### Conan Installer

--- a/legacy/docker-compose.yml
+++ b/legacy/docker-compose.yml
@@ -496,22 +496,6 @@ services:
         image: "${DOCKER_USERNAME}/clang7-x86:${DOCKER_BUILD_TAG}"
         container_name: clang7-x86
         tty: true
-    conan_server:
-        build:
-            context: conan_server
-            dockerfile: Dockerfile
-            args:
-                CONAN_VERSION: ${DOCKER_BUILD_TAG}
-        image: "${DOCKER_USERNAME}/conan_server:${DOCKER_BUILD_TAG}"
-        container_name: conan_server
-    conan:
-        build:
-            context: conan_client
-            dockerfile: Dockerfile
-            args:
-                CONAN_VERSION: ${DOCKER_BUILD_TAG}
-        image: "${DOCKER_USERNAME}/conan:${DOCKER_BUILD_TAG}"
-        container_name: conan_client
     clang8:
         build:
             context: clang_8

--- a/modern/README.md
+++ b/modern/README.md
@@ -123,16 +123,6 @@ Tags will use the Conan version available in those images.
 | [conanio/clang14-ubuntu16.04: clang 14](https://hub.docker.com/r/conanio/clang14-ubuntu16.04/) | x86_64 | :white_check_mark: Supported |
 
 
-
-### Conan Server
-
-Conan Docker Tools provides an image version with only Conan Server installed, very useful for the cases it is necessary to run a server without touching the host. It's based on Alpine.
-
-| Version                                                                | Arch   | Status, Life cycle           |
-|------------------------------------------------------------------------|--------|------------------------------|
-| [conanio/conan_server](https://hub.docker.com/r/conanio/conan_server/) | ANY    | :white_check_mark: Supported |
-
-
 ### Jenkins Client
 
 If you use Jenkins to build your packages and also you use Jenkins clients to run each docker container, you could use our Docker images prepared for Jenkins. Those images run the script [jenkins-client.sh](jenkins/jenkins-client), which starts the client during the container entrypoint.


### PR DESCRIPTION
Both images are generated only for Conan 1.x that is no longer recommended.

There is no plan for supporting those images in Conan 2.x. Instead, Conan offers a good flavor of ways to install both Conan client and Artifactory. 

The Conan client can be installed with a self-contained executable, much easier than using pypi or any other system package manager.

The Artifactory CE has docker image maintained by JFrog. Plus, has more features than Conan Server.

Both can be found on Conan's download page: https://conan.io/downloads 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
