### PR TITLE
Do not support x86 in active legacy images

### DIFF
--- a/legacy/docker-compose.yml
+++ b/legacy/docker-compose.yml
@@ -568,41 +568,6 @@ services:
         image: "${DOCKER_USERNAME}/msvc15:${DOCKER_BUILD_TAG}"
         container_name: msvc15
         tty: true
-    android-clang8:
-        build:
-            context: android-clang_8
-            dockerfile: Dockerfile
-            args:
-                CONAN_VERSION: ${DOCKER_BUILD_TAG}
-        image: "${DOCKER_USERNAME}/android-clang8:${DOCKER_BUILD_TAG}"
-        container_name: android-clang8
-        tty: true
-    android-clang8-x86:
-        build:
-            context: android-clang_8-x86
-            dockerfile: Dockerfile
-            args:
-                CONAN_VERSION: ${DOCKER_BUILD_TAG}
-        image: "${DOCKER_USERNAME}/android-clang8-x86:${DOCKER_BUILD_TAG}"
-        container_name: android-clang8-x86
-        tty: true
-    android-clang8-armv7:
-        build:
-            context: android-clang_8-armv7
-            dockerfile: Dockerfile
-            args:
-                CONAN_VERSION: ${DOCKER_BUILD_TAG}
-        image: "${DOCKER_USERNAME}/android-clang8-armv7:${DOCKER_BUILD_TAG}"
-        container_name: android-clang8-armv7
-        tty: true
-    android-clang8-armv8:
-        build:
-            context: android-clang_8-armv8
-            dockerfile: Dockerfile
-            args:
-                CONAN_VERSION: ${DOCKER_BUILD_TAG}
-        image: "${DOCKER_USERNAME}/android-clang8-armv8:${DOCKER_BUILD_TAG}"
-        container_name: android-clang8-armv8
     android-clang14:
         build:
             context: android-clang_14

--- a/legacy/docker-compose.yml
+++ b/legacy/docker-compose.yml
@@ -641,7 +641,7 @@ services:
     # Jenkins Images
     gcc46-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc46:${DOCKER_BUILD_TAG}
@@ -652,7 +652,7 @@ services:
         tty: true
     gcc48-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc48:${DOCKER_BUILD_TAG}
@@ -664,7 +664,7 @@ services:
         tty: true
     gcc49-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc49:${DOCKER_BUILD_TAG}
@@ -675,7 +675,7 @@ services:
         container_name: gcc49-jenkins
     gcc5-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc5:${DOCKER_BUILD_TAG}
@@ -686,7 +686,7 @@ services:
         container_name: gcc5-jenkins
     gcc6-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc6:${DOCKER_BUILD_TAG}
@@ -697,7 +697,7 @@ services:
         container_name: gcc6-jenkins
     gcc7-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc7:${DOCKER_BUILD_TAG}
@@ -708,7 +708,7 @@ services:
         container_name: gcc7-jenkins
     gcc8-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc8:${DOCKER_BUILD_TAG}
@@ -719,7 +719,7 @@ services:
         container_name: gcc8-jenkins
     gcc9-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc9:${DOCKER_BUILD_TAG}
@@ -730,7 +730,7 @@ services:
         container_name: gcc9-jenkins
     gcc10-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc10:${DOCKER_BUILD_TAG}
@@ -741,7 +741,7 @@ services:
         container_name: gcc10-jenkins
     gcc11-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/gcc11:${DOCKER_BUILD_TAG}
@@ -752,7 +752,7 @@ services:
         container_name: gcc11-jenkins
     clang39-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang39:${DOCKER_BUILD_TAG}
@@ -764,7 +764,7 @@ services:
         tty: true
     clang40-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang40:${DOCKER_BUILD_TAG}
@@ -776,7 +776,7 @@ services:
         tty: true
     clang50-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang50:${DOCKER_BUILD_TAG}
@@ -788,7 +788,7 @@ services:
         tty: true
     clang60-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang60:${DOCKER_BUILD_TAG}
@@ -800,7 +800,7 @@ services:
         tty: true
     clang7-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang7:${DOCKER_BUILD_TAG}
@@ -812,7 +812,7 @@ services:
         tty: true
     clang8-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang8:${DOCKER_BUILD_TAG}
@@ -824,7 +824,7 @@ services:
         tty: true
     clang9-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang9:${DOCKER_BUILD_TAG}
@@ -836,7 +836,7 @@ services:
         tty: true
     clang10-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang10:${DOCKER_BUILD_TAG}
@@ -848,7 +848,7 @@ services:
         tty: true
     clang11-jenkins:
         build:
-            context: jenkins-jenkins
+            context: jenkins
             dockerfile: Dockerfile
             args:
                 SOURCE_CONANIO_IMAGE: conanio/clang11:${DOCKER_BUILD_TAG}

--- a/legacy/gcc_5/Dockerfile
+++ b/legacy/gcc_5/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:xenial
 
 LABEL maintainer="Conan.io <info@conan.io>"
 
-ARG CONAN_VERSION
-
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
@@ -79,9 +77,7 @@ RUN wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.c
        && pyenv global 3.7.13 \
        && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py
 
-RUN pip install -q --upgrade --no-cache-dir pip \
-       && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
-       && chown -R conan:1001 /opt/pyenv \
+RUN chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
        && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
        && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
@@ -107,6 +103,11 @@ RUN apt-get -qq purge -y \
        && apt-get -qq autoclean \
        && apt-get -qq update \
        && rm -rf /var/lib/apt/lists/*
+
+ARG CONAN_VERSION
+
+RUN pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan==${CONAN_VERSION}
 
 USER conan
 WORKDIR /home/conan

--- a/legacy/gcc_5/Dockerfile
+++ b/legacy/gcc_5/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+LABEL maintainer="Conan.io <info@conan.io>"
 
 ARG CONAN_VERSION
 
@@ -12,8 +12,7 @@ ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CC=/usr/bin/gcc \
     FC=/usr/bin/gfortran
 
-RUN dpkg --add-architecture i386 \
-    && apt-get -qq update \
+RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends software-properties-common \
     && add-apt-repository ppa:git-core/ppa -y \
     && apt-get -qq update \
@@ -47,8 +46,9 @@ RUN dpkg --add-architecture i386 \
        liblzma-dev \
        ca-certificates \
        autoconf-archive \
-       && rm -rf /var/lib/apt/lists/* \
-       && wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+       && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q --no-check-certificate https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
        && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
           --exclude=bin/cmake-gui \
           --exclude=doc/cmake \
@@ -56,8 +56,9 @@ RUN dpkg --add-architecture i386 \
        --exclude=share/vim \
        && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
        && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-       && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-       && curl -fL https://getcli.jfrog.io | sh \
+       && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz
+
+RUN curl -fL https://getcli.jfrog.io | sh \
        && mv jfrog /usr/local/bin/jfrog \
        && chmod +x /usr/local/bin/jfrog \
        && groupadd -f conan-1001 -g 1001 \
@@ -67,16 +68,18 @@ RUN dpkg --add-architecture i386 \
        && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
        && printf "conan:conan" | chpasswd \
        && adduser conan sudo \
-       && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
-       && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+       && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
+
+RUN wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
        && chmod +x /tmp/pyenv-installer \
        && /tmp/pyenv-installer \
        && rm /tmp/pyenv-installer \
        && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
        && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.13 \
        && pyenv global 3.7.13 \
-       && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py \
-       && pip install -q --upgrade --no-cache-dir pip \
+       && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py
+
+RUN pip install -q --upgrade --no-cache-dir pip \
        && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
        && chown -R conan:1001 /opt/pyenv \
        # remove all __pycache__ directories created by pyenv
@@ -84,8 +87,9 @@ RUN dpkg --add-architecture i386 \
        && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
        && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
        && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
-       && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
-       && apt-get -qq purge -y \
+       && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+
+RUN apt-get -qq purge -y \
           libgmp-dev \
           libmpfr-dev \
           libmpc-dev \

--- a/legacy/gcc_7/Dockerfile
+++ b/legacy/gcc_7/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+LABEL maintainer="Conan.io <info@conan.io>"
 
 ARG CONAN_VERSION
 
@@ -12,8 +12,7 @@ ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CC=/usr/bin/gcc \
     FC=/usr/bin/gfortran
 
-RUN dpkg --add-architecture i386 \
-    && apt-get -qq update \
+RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends software-properties-common \
     && add-apt-repository ppa:git-core/ppa -y \
     && apt-get -qq update \
@@ -22,10 +21,9 @@ RUN dpkg --add-architecture i386 \
        binutils \
        wget \
        git \
-       libc6-dev-i386 \
-       linux-libc-dev:i386 \
-       g++-7-multilib \
-       gfortran-7-multilib \
+       linux-libc-dev \
+       g++-7 \
+       gfortran-7 \
        libgmp-dev \
        libmpfr-dev \
        libmpc-dev \
@@ -57,8 +55,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-7 100 \
     && update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
@@ -66,8 +65,10 @@ RUN dpkg --add-architecture i386 \
        --exclude=share/vim \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && curl -fL https://getcli.jfrog.io | sh \
+    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz
+
+
+RUN curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd -f conan-1001 -g 1001 \
@@ -77,16 +78,18 @@ RUN dpkg --add-architecture i386 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
-    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
-    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
+
+RUN wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.13 \
     && pyenv global 3.7.13 \
-    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py \
-    && pip install -q --upgrade --no-cache-dir pip \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py
+
+RUN pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
@@ -94,8 +97,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
-    && apt-get -qq purge -y \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+
+RUN apt-get -qq purge -y \
           libgmp-dev \
           libmpfr-dev \
           libmpc-dev \

--- a/legacy/gcc_7/Dockerfile
+++ b/legacy/gcc_7/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:bionic
 
 LABEL maintainer="Conan.io <info@conan.io>"
 
-ARG CONAN_VERSION
-
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
@@ -89,9 +87,7 @@ RUN wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.c
     && pyenv global 3.7.13 \
     && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py
 
-RUN pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
-    && chown -R conan:1001 /opt/pyenv \
+RUN chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
@@ -117,6 +113,11 @@ RUN apt-get -qq purge -y \
        && apt-get -qq autoclean \
        && apt-get -qq update \
        && rm -rf /var/lib/apt/lists/*
+
+ARG CONAN_VERSION
+
+RUN pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan==${CONAN_VERSION}
 
 USER conan
 WORKDIR /home/conan

--- a/legacy/gcc_9/Dockerfile
+++ b/legacy/gcc_9/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:eoan
 
-LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+LABEL maintainer="Conan.io <info@conan.io>"
 
 ARG CONAN_VERSION
 
@@ -14,8 +14,7 @@ ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
 
 COPY sources.list /etc/apt/sources.list
 
-RUN dpkg --add-architecture i386 \
-    && apt-get -qq update \
+RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends software-properties-common \
     && add-apt-repository ppa:git-core/ppa -y \
     && apt-get -qq update \
@@ -24,11 +23,10 @@ RUN dpkg --add-architecture i386 \
        binutils \
        wget \
        git \
-       libc6-dev-i386 \
        libc6-dev \
-       linux-libc-dev:i386 \
-       g++-9-multilib \
-       gfortran-9-multilib \
+       linux-libc-dev \
+       g++-9 \
+       gfortran-9 \
        libgmp-dev \
        libmpfr-dev \
        libmpc-dev \
@@ -59,8 +57,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-9 100 \
     && update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-9 100 \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget --no-check-certificate --quiet https://cmake.org/files/v${CMAKE_VERSION_MAJOR_MINOR}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
     && tar -xzf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
        --exclude=bin/cmake-gui \
        --exclude=doc/cmake \
@@ -68,8 +67,9 @@ RUN dpkg --add-architecture i386 \
        --exclude=share/vim \
     && cp -fR cmake-${CMAKE_VERSION_FULL}-Linux-x86_64/* /usr \
     && rm -rf cmake-${CMAKE_VERSION_FULL}-Linux-x86_64 \
-    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz \
-    && curl -fL https://getcli.jfrog.io | sh \
+    && rm cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.tar.gz
+
+RUN curl -fL https://getcli.jfrog.io | sh \
     && mv jfrog /usr/local/bin/jfrog \
     && chmod +x /usr/local/bin/jfrog \
     && groupadd -f conan-1001 -g 1001 \
@@ -79,16 +79,18 @@ RUN dpkg --add-architecture i386 \
     && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
     && printf "conan:conan" | chpasswd \
     && adduser conan sudo \
-    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
-    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
+
+RUN wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
     && chmod +x /tmp/pyenv-installer \
     && /tmp/pyenv-installer \
     && rm /tmp/pyenv-installer \
     && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
     && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.13 \
     && pyenv global 3.7.13 \
-    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py \
-    && pip install -q --upgrade --no-cache-dir pip \
+    && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py
+
+RUN pip install -q --upgrade --no-cache-dir pip \
     && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
     && chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
@@ -96,8 +98,9 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
     && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
     && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100 \
-    && apt-get -qq purge -y \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+
+RUN apt-get -qq purge -y \
           libgmp-dev \
           libmpfr-dev \
           libmpc-dev \

--- a/legacy/gcc_9/Dockerfile
+++ b/legacy/gcc_9/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:eoan
 
 LABEL maintainer="Conan.io <info@conan.io>"
 
-ARG CONAN_VERSION
-
 ENV CMAKE_VERSION_MAJOR_MINOR=3.18 \
     CMAKE_VERSION_FULL=3.18.2 \
     PYENV_ROOT=/opt/pyenv \
@@ -90,9 +88,7 @@ RUN wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.c
     && pyenv global 3.7.13 \
     && ln -s /usr/lib/python3/dist-packages/lsb_release.py /opt/pyenv/versions/3.7.13/lib/python3.7/lsb_release.py
 
-RUN pip install -q --upgrade --no-cache-dir pip \
-    && pip install -q --no-cache-dir conan==${CONAN_VERSION} conan-package-tools \
-    && chown -R conan:1001 /opt/pyenv \
+RUN chown -R conan:1001 /opt/pyenv \
     # remove all __pycache__ directories created by pyenv
     && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
     && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
@@ -118,6 +114,11 @@ RUN apt-get -qq purge -y \
        && apt-get -qq autoclean \
        && apt-get -qq update \
        && rm -rf /var/lib/apt/lists/*
+
+ARG CONAN_VERSION
+
+RUN pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan==${CONAN_VERSION}
 
 USER conan
 WORKDIR /home/conan


### PR DESCRIPTION
The only still active legacy GCC images: GCC 5, 7 and 9 are installing x86 support, but it's not used in CCI since few years.

This PR removes those steps that 32-bit libraries and tools.

Plus, it splits the Docker recipe in several steps. It will result in a bit bigger image, but will be much easier to debug when failing to build. Errors occurs with frequency, or because a networking error, or an outdated certified, etc.

Plus, fixed the docker-compose file with not supported builds (This file is not used by the CI).

It should be only merged after the PR #566 