### PR TITLE
[bugfix] Fix Conan version parse in Jenkins

### DIFF
--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -66,8 +66,7 @@ node('Linux') {
         if (params.conan_versions) {
             List parsedVersions = parseParamVersions(params.conan_versions)
             // INFO: Check that all versions are valid
-            parsedVersions.collect{ parseVersion(it) }
-            conanVersions = parsedVersions
+            conanVersions = parsedVersions.collect{ parseVersion(it) }
             echo "INFO: Skipping Conan versions computation because of input parameter."
             return
         }
@@ -89,7 +88,7 @@ node('Linux') {
             echo "Read latest version from pypi"
             def response = httpRequest(url: 'https://pypi.org/pypi/conan/json')
             Map<String, Object> requestJson = readJSON(text: response.content)
-            latestVersion = requestJson.info.version
+            latestVersion = parseVersion(requestJson.info.version)
             def keyVersions = requestJson.releases.keySet()
 
             echo "INFO: Latest version available in pypi: ${latestVersion}"
@@ -114,15 +113,15 @@ node('Linux') {
 
                     if (version[0] > minVersion[0] && !hasPreVersion(release)) {
                         echo "DEBUG: Adding '$release' to the list of versions because of major version."
-                        conanVersions.add(release)
+                        conanVersions.add(version)
                     }
                     else if (version[0] == minVersion[0] && version[1] > minVersion[1]) {
                         echo "DEBUG: Adding '$release' to the list of versions because of minor version."
-                        conanVersions.add(release)
+                        conanVersions.add(version)
                     }
                     else if (version[0] == minVersion[0] && version[1] == minVersion[1] &&  version[2] >= minVersion[2]) {
                         echo "DEBUG: Adding '$release' to the list of versions because of patch version."
-                        conanVersions.add(release)
+                        conanVersions.add(version)
                     }
                 }
                 catch(e) {
@@ -210,8 +209,9 @@ node('Linux') {
     parameters.add([$class: 'BooleanParameterValue', name: 'upload_jenkins_images', value: true])
     parameters.add([$class: 'BooleanParameterValue', name: 'dry_run', value: params.dry_run])
 
-    for (strVersion in conanVersions) {
-        boolean isLatest = (strVersion == latestVersion)
+    for (v in conanVersions) {
+        String strVersion = "${v[0]}.${v[1]}.${v[2]}"
+        boolean isLatest = (v == latestVersion)
         stage("Build images for Conan '${strVersion}' (latest=${isLatest})") {
             // INFO: When building docker images, networking errors are frequent. We retry 3 times.
             retry(3) {

--- a/.ci/conan_center_index.jenkinsfile
+++ b/.ci/conan_center_index.jenkinsfile
@@ -66,7 +66,8 @@ node('Linux') {
         if (params.conan_versions) {
             List parsedVersions = parseParamVersions(params.conan_versions)
             // INFO: Check that all versions are valid
-            conanVersions = parsedVersions.collect{ parseVersion(it) }
+            parsedVersions.collect{ parseVersion(it) }
+            conanVersions = parsedVersions
             echo "INFO: Skipping Conan versions computation because of input parameter."
             return
         }


### PR DESCRIPTION
The Conan version should be parsed to a list, then converted to a string when needed.


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
