### PR TITLE
[bugfix] Compiler versions param should be string

### DIFF
--- a/.ci/generate.jenkinsfile
+++ b/.ci/generate.jenkinsfile
@@ -22,6 +22,16 @@ String getVersionMajor(String version) {
     return major
 }
 
+List<String> parseParamVersions(String versions) {
+    List<String> result = []
+    versions.split(',').each { v ->
+        String version = v.trim()
+        if (version.size() > 0) {
+            result.add(version)
+        }
+    }
+    return result
+}
 
 def buildImage(String latestMaster, String latestBranch, String expectedImage, String buildArgs, String target = null, String extraCacheFrom = null) {
     withCredentials([usernamePassword(credentialsId: 'center-c3i-docker', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -85,8 +95,8 @@ def checkoutSources() {
 }
 
 node('Linux') {
-    List<String> gccVersions = params.gcc_versions.split("\n")
-    List<String> clangVersions = params.clang_versions.split("\n")
+    List<String> gccVersions = parseParamVersions(params.gcc_versions)
+    List<String> clangVersions = parseParamVersions(clang_versions)
 
 
     stage('Input parameters') {
@@ -123,8 +133,8 @@ node('Linux') {
 
         echo """
         Images to generate:
-        - gcc_versions: ${gccVersions.join(', ')}
-        - clang_versions: ${clangVersions.join(', ')}
+        - gcc_versions: ${gccVersions}
+        - clang_versions: ${clangVersions}
         - libstdcpp_version: ${params.libstdcpp_version}
         - libstdcpp_patch_version: ${params.libstdcpp_patch_version}
         - libstdcpp_major_version: ${params.libstdcpp_major_version}


### PR DESCRIPTION
Using string multi line in Jenkins is hard when passing values directly to the web interface and very fragile when using re-build action. Parsing string with commas is safer. 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan-docker-tools/blob/master/.github/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008) style guides for Python code.
- [ ] I've followed the [Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) guides for Dockerfile.
