### PR TITLE
Split jenkins images steps

### DIFF
--- a/legacy/jenkins/Dockerfile
+++ b/legacy/jenkins/Dockerfile
@@ -1,14 +1,10 @@
 ARG SOURCE_CONANIO_IMAGE
 FROM $SOURCE_CONANIO_IMAGE as base
 
-ARG JENKINS_AGENT_VERSION
-ARG CONAN_VERSION
 ARG JAVA_JDK_VERSION=11
 
 USER root
 
-COPY jenkins-client /usr/local/bin/jenkins-client
-COPY entrypoint.sh /opt/entrypoint.sh
 COPY install-openjdk-ppa.sh /tmp/install-openjdk-ppa.sh
 
 RUN /tmp/install-openjdk-ppa.sh \
@@ -16,12 +12,21 @@ RUN /tmp/install-openjdk-ppa.sh \
     && apt-get -q install -y openjdk-${JAVA_JDK_VERSION}-jre-headless  curl \
     && apt-get -q clean -y \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -f /var/cache/apt/*.bin \
-    && pip3 install --no-cache conan==${CONAN_VERSION} virtualenv \
-    && curl --create-dirs -sSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${JENKINS_AGENT_VERSION}/remoting-${JENKINS_AGENT_VERSION}.jar \
+    && rm -f /var/cache/apt/*.bin
+
+COPY jenkins-client /usr/local/bin/jenkins-client
+COPY entrypoint.sh /opt/entrypoint.sh
+
+ARG JENKINS_AGENT_VERSION
+
+RUN curl --create-dirs -sSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${JENKINS_AGENT_VERSION}/remoting-${JENKINS_AGENT_VERSION}.jar \
     && chmod 755 /usr/share/jenkins \
     && chmod 644 /usr/share/jenkins/agent.jar \
     && chmod +x /opt/entrypoint.sh /usr/local/bin/jenkins-client
+
+ARG CONAN_VERSION
+
+RUN pip3 install --no-cache conan==${CONAN_VERSION} virtualenv
 
 ENTRYPOINT ["/opt/entrypoint.sh"]
 USER conan

--- a/modern/jenkins/Dockerfile
+++ b/modern/jenkins/Dockerfile
@@ -1,17 +1,14 @@
 ARG SOURCE_CONANIO_IMAGE
 FROM $SOURCE_CONANIO_IMAGE as base
 
-ARG JENKINS_AGENT_VERSION
-ARG JAVA_JDK_VERSION=11
-
 USER root
 
-COPY jenkins-client /usr/local/bin/jenkins-client
-COPY entrypoint.sh /opt/entrypoint.sh
 COPY install-openjdk-ppa.sh /tmp/install-openjdk-ppa.sh
 COPY cacert /etc/ssl/certs/java/cacerts
 
 # INFO: OpenJDK11 wants cacert but is not installed and the Keystore type is not the expected: https://stackoverflow.com/questions/6784463/error-trustanchors-parameter-must-be-non-empty
+
+ARG JAVA_JDK_VERSION=11
 
 RUN /tmp/install-openjdk-ppa.sh \
     && apt-get -qq update \
@@ -19,8 +16,14 @@ RUN /tmp/install-openjdk-ppa.sh \
     && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
     && apt-get -q clean -y \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -f /var/cache/apt/*.bin \
-    && pip3 install --no-cache virtualenv \
+    && rm -f /var/cache/apt/*.bin
+
+COPY entrypoint.sh /opt/entrypoint.sh
+COPY jenkins-client /usr/local/bin/jenkins-client
+
+ARG JENKINS_AGENT_VERSION
+
+RUN pip3 install --no-cache virtualenv \
     && curl --create-dirs -sSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${JENKINS_AGENT_VERSION}/remoting-${JENKINS_AGENT_VERSION}.jar \
     && chmod 755 /usr/share/jenkins \
     && chmod 644 /usr/share/jenkins/agent.jar \


### PR DESCRIPTION
Jenkins images are relative small, but they are not caching as expected. This PR should run separated steps to improve it. 
